### PR TITLE
[PRIVMSG] 宛先なしの411Errorの追加

### DIFF
--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -35,6 +35,7 @@ public:
                                    const std::string &target);
   static std::string errNoSuchChannel(const std::string &clientName,
                                       const std::string &channelName);
+  static std::string errNoRecipient(const std::string &command);
   static std::string errNoOrigin(const std::string &clientName);
   static std::string errNoTextToSend(const std::string &clientName);
   static std::string errNoNicknameGiven();

--- a/src/commands/PrivMsgCommand.cpp
+++ b/src/commands/PrivMsgCommand.cpp
@@ -6,7 +6,11 @@ PrivMsgCommand::PrivMsgCommand(ServerContext &serverCtx)
 PrivMsgCommand::~PrivMsgCommand() {}
 
 bool PrivMsgCommand::execute(CommandContext &ctx) {
-  if (ctx.params().size() < 2) {
+  if (ctx.params().empty()) {
+    ctx.reply(ReplyBuilder::errNoRecipient("PRIVMSG"));
+    return true;
+  }
+  if (ctx.params().size() < 2 || ctx.params()[1].empty()) {
     ctx.reply(ReplyBuilder::errNoTextToSend(ctx.nick()));
     return true;
   }

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -61,6 +61,10 @@ std::string ReplyBuilder::errCantSendToChannel(const std::string &clientName,
   return "404 " + clientName + " " + channelName + " :Cannot send to channel";
 }
 
+std::string ReplyBuilder::errNoRecipient(const std::string &command) {
+  return "411 :No recipient given (" + command + ")";
+}
+
 std::string ReplyBuilder::errNoOrigin(const std::string &clientName) {
   return "409 " + clientName + " :No origin specified";
 }


### PR DESCRIPTION
RFC1458とRFC2812でTrailingの扱い方が違って、それによって微妙に412か411かが変わるみたいだが、2812の解釈じゃないと、パース部分の変更がめんどくさそうだから2812Verで