### PR TITLE
MODEのユーザー数制限値を検証

### DIFF
--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -66,6 +66,10 @@ class ReplyBuilder {
                                       const std::string& channelName);
   static std::string errUnknownMode(const std::string& clientName, char c,
                                     const std::string& chName);
+  static std::string errInvalidModeParam(const std::string& clientName,
+                                         const std::string& channelName,
+                                         char mode,
+                                         const std::string& parameter);
   static std::string errBadChannelKey(const std::string& clientName,
                                       const std::string& channelName);
   static std::string errInviteOnlyChan(const std::string& clientName,

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -1,7 +1,27 @@
 #include "ModeCommand.hpp"
 #include "ReplyBuilder.hpp"
-#include <cstdlib>
 #include <sstream>
+
+namespace {
+bool parsePositiveSize(const std::string &value, size_t &result) {
+  if (value.empty())
+    return false;
+
+  result = 0;
+  for (std::string::const_iterator it = value.begin(); it != value.end();
+       ++it) {
+    if (*it < '0' || *it > '9')
+      return false;
+
+    size_t digit = static_cast<size_t>(*it - '0');
+    if (result > (static_cast<size_t>(-1) - digit) / 10)
+      return false;
+
+    result = result * 10 + digit;
+  }
+  return result > 0;
+}
+} // namespace
 
 ModeCommand::ModeCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
 ModeCommand::~ModeCommand() {}
@@ -114,7 +134,13 @@ bool ModeCommand::execute(CommandContext &ctx) {
           ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "MODE"));
           return true;
         }
-        channel->setUserLimit(std::atoi(ctx.params()[paramIndex].c_str()));
+        size_t limit;
+        if (!parsePositiveSize(ctx.params()[paramIndex], limit)) {
+          ctx.reply(ReplyBuilder::errInvalidModeParam(
+              ctx.nick(), chName, 'l', ctx.params()[paramIndex]));
+          return true;
+        }
+        channel->setUserLimit(limit);
         modeParams += " " + ctx.params()[paramIndex++];
       } else {
         channel->setUserLimit(0);

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -145,6 +145,15 @@ std::string ReplyBuilder::errUnknownMode(const std::string& clientName, char c,
          " :is unknown mode char to me for " + chName;
 }
 
+std::string ReplyBuilder::errInvalidModeParam(const std::string& clientName,
+                                              const std::string& channelName,
+                                              char mode,
+                                              const std::string& parameter) {
+  return "696 " + clientName + " " + channelName + " " +
+         std::string(1, mode) + " " + parameter +
+         " :Invalid mode parameter";
+}
+
 std::string ReplyBuilder::errInviteOnlyChan(const std::string& clientName,
                                             const std::string& channelName) {
   return "473 " + clientName + " " + channelName + " :Cannot join channel (+i)";


### PR DESCRIPTION
## 概要

`MODE +l` でチャンネルのユーザー数上限を設定する際に、引数が有効な正の整数か検証するように修正しました。

## 変更内容

- `std::atoi()` による変換を廃止
- `+l` の引数が正の整数であることを検証
- `0`、負数、数字以外を含む値、`size_t` を超える巨大値を拒否
- 不正な mode parameter に対して `696 ... :Invalid mode parameter` を返す処理を追加

## 意図

`MODE +l` はチャンネルの参加人数上限を設定する mode です。  
不正な値をそのまま内部状態に反映すると、`0` による意図しない制限解除相当の挙動や、負数による巨大な `size_t` 値の設定が起こる可能性があります。

そのため、上限値として意味のある正の整数だけを受け付けるようにしました。
