### PR TITLE
fix: extractMessage を CRLF/LF 両対応にし末尾 CR を除去

### DIFF
--- a/src/domain/Client.cpp
+++ b/src/domain/Client.cpp
@@ -110,20 +110,19 @@ void Client::appendRecvBuffer(const std::string& data) {
 }
 
 std::string Client::extractMessage() {
-  // macのncは\nしかいれてくれないので仮で
-  // あとで絶対戻すうおうおうおうおうおう
-  std::string::size_type pos = _recvBuffer.find("\n");
-  //   std::string::size_type pos = _recvBuffer.find("\r\n");
-
+  // RFC 2812: メッセージ境界は CR-LF。ただし nc など LF のみで送るクライアントも
+  // 実運用では珍しくないため、LF を境界として検出しつつ、直前の CR を除去して
+  // 両方の終端表現を受け付ける。
+  std::string::size_type pos = _recvBuffer.find('\n');
   if (pos == std::string::npos)
     return "";
 
-  std::string msg = _recvBuffer.substr(0, pos);
+  std::string::size_type msgEnd = pos;
+  if (msgEnd > 0 && _recvBuffer[msgEnd - 1] == '\r')
+    --msgEnd;
 
+  std::string msg = _recvBuffer.substr(0, msgEnd);
   _recvBuffer.erase(0, pos + 1);
-  // ここも戻すうおうおうおう
-  // _recvBuffer.erase(0, pos + 2);
-
   return msg;
 }
 


### PR DESCRIPTION
Closes #54

## 概要
`Client::extractMessage()` を CRLF/LF 両対応にし、境界の直前にある CR を除去するように修正。

## 変更内容
- LF (`\n`) を境界として検出
- 直前の CR があれば除去してから message を切り出す
- 本文中の CR は保持(末尾のみ除去)
- 「あとで絶対戻す」のコメント/仮対応コードを削除し、意図を RFC 参照つきで書き直し

## テスト
| ケース | 期待 | 結果 |
|---|---|---|
| CRLF 終端(`NICK alice\r\n`) | msg=`NICK alice` | ✅ |
| LF 単独(`NICK alice\n`) | msg=`NICK alice` | ✅ |
| 空行(`\r\n` 単独) | msg=`""` | ✅ |
| 本文中の CR(`PRIVMSG t :hi\rlo\r\n`) | trailing=`hi\rlo` | ✅ |
| Split packet(`\r` 送信 → 0.2s 後 `\n`) | 1 メッセージとして取れる | ✅ |

## サブエージェントレビュー結果
LGTM(1件 MINOR、pre-existing の別バグ指摘のみ)。
Server.cpp:268 の while ループが `""` センチネル終端で早期 break する pre-existing 問題は別 issue でフォローアップ予定。

## Refs
- RFC 2812 §2.3
- 既存 issue: #54