### PR TITLE
fix: PONG 応答の token を trailing パラメータ形式に修正

### DIFF
--- a/src/commands/PingCommand.cpp
+++ b/src/commands/PingCommand.cpp
@@ -10,6 +10,9 @@ bool PingCommand::execute(CommandContext &ctx) {
     return true;
   }
 
-  ctx.reply("PONG " + ctx.params()[0]);
+  // trailing パラメータとして token をエコーする (RFC 2812 §3.7.3)。
+  // leading server prefix (":<servername> ") は #56 で ResponseSink 側に一括
+  // 導入する予定のためここでは付与しない。
+  ctx.reply("PONG :" + ctx.params()[0]);
   return true;
 }


### PR DESCRIPTION
Closes #55

## 概要
`PING` に対する応答 `PONG` の token を **trailing パラメータ** (`:<token>`) として返すよう修正。

## 変更内容
`src/commands/PingCommand.cpp`
- 旧: `PONG <token>` (colon なし、param が空白を含めない)
- 新: `PONG :<token>` (colon 付き trailing、空白許容 RFC 2812 §3.7.3 準拠)

## テスト
| 入力 | 応答 |
|---|---|
| `PING :12345` | `PONG :12345` |
| `PING abcdef` | `PONG :abcdef` |
| `PING` (引数無し) | `409 :No origin specified` |

## スコープ判断
- **leading server prefix (`:<servername> PONG ...`)** は追加しない
  → #56 が `ResponseSink` 側で全 reply に一括付与する予定のため、ここで付けると重複する
- **middle `<server>` param** も追加しない
  → 単一サーバー構成では `<server2>` フォワーディングが発生しないため最小修正で十分

## サブエージェントレビュー結果
LGTM。指摘 2 件はいずれも #56 との協調事項:
1. #56 で全 reply に `:server` を付与する際、既に prefix を持つ行と重複しないよう分岐必要
2. strict client が leading prefix を要求する場合は #55 単独では完全解決しない

いずれも #56 で回収予定。

## Refs
- RFC 2812 §3.7.3 (PONG)
- Related: #56 (server prefix 一括導入)