### PR TITLE
fix: ERR_KEYSET (467) に client nick を追加

### DIFF
--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -70,7 +70,8 @@ class ReplyBuilder {
                                       const std::string& channelName);
   static std::string errInviteOnlyChan(const std::string& clientName,
                                        const std::string& channelName);
-  static std::string errKeySet(const std::string& channelName);
+  static std::string errKeySet(const std::string& clientName,
+                               const std::string& channelName);
   static std::string errIncorrectPassword();
 };
 

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -79,7 +79,7 @@ bool ModeCommand::execute(CommandContext &ctx) {
           return true;
         }
         if (!channel->getPassword().empty()) {
-          ctx.reply(ReplyBuilder::errKeySet(chName));
+          ctx.reply(ReplyBuilder::errKeySet(ctx.nick(), chName));
           return true;
         }
         channel->setPassword(ctx.params()[paramIndex]);

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -155,8 +155,9 @@ std::string ReplyBuilder::errBadChannelKey(const std::string& clientName,
   return "475 " + clientName + " " + channelName + " :Cannot join channel (+k)";
 }
 
-std::string ReplyBuilder::errKeySet(const std::string& channelName) {
-  return "467 " + channelName + " :Channel key already set";
+std::string ReplyBuilder::errKeySet(const std::string& clientName,
+                                    const std::string& channelName) {
+  return "467 " + clientName + " " + channelName + " :Channel key already set";
 }
 
 std::string ReplyBuilder::errChanOPrivsNeeded(const std::string& clientName,


### PR DESCRIPTION
Closes #58

## 概要
`ERR_KEYSET` (467) 応答フォーマットに client nick が欠落していた問題を修正。
RFC 2812 §2.4 では numeric reply の第1引数は常に対象 client の nick。

## 変更内容
- `include/response/ReplyBuilder.hpp` — `errKeySet` に `clientName` 引数追加(第1引数)
- `src/response/ReplyBuilder.cpp` — 実装を新シグネチャに合わせて更新
- `src/commands/ModeCommand.cpp:82` — 唯一の呼び出し側を `ctx.nick()` 渡しに更新

## Before / After
| | 応答 |
|---|---|
| Before | `467 #kk :Channel key already set` |
| After | `467 aa #kk :Channel key already set` |

## テスト
```
JOIN #kk
MODE #kk +k first    → :aa!aa@127.0.0.1 MODE #kk +k first
MODE #kk +k second   → 467 aa #kk :Channel key already set  ✅
```

## サブエージェントレビュー結果
LGTM。呼び出し側は `grep -rn "errKeySet"` で 1 箇所(修正済) のみ確認。
副次的に指摘された 421 (`errUnknownCommand`) と 411 (`errNoRecipient`) の同種 nick 欠落は本 PR のスコープ外、別 issue でフォローアップします。

## Refs
- RFC 2812 §2.4 / §5.2 (ERR_KEYSET)