### PR TITLE
fix: PRIVMSG で存在しないチャネル宛が 401 になる問題を修正

### DIFF
--- a/src/core/MsgTargetResolver.cpp
+++ b/src/core/MsgTargetResolver.cpp
@@ -72,7 +72,7 @@ MsgTargetResolveResult MsgTargetResolver::_resolveChannelToken(
   Channel* channel = _serverCtx.findChannel(token);
 
   if (channel == NULL)
-    return MSGTARGET_RESOLVE_NO_SUCH_NICK;
+    return MSGTARGET_RESOLVE_NO_SUCH_CHANNEL;
 
   target.channel = channel;
   return MSGTARGET_RESOLVE_OK;


### PR DESCRIPTION
Closes #51

## 概要
`PRIVMSG #nonexist :hi` のように存在しないチャネル宛に PRIVMSG を送ると `401 :No such nick/channel` が返っていた。RFC 2812 §3.3.1 に従い `403 :No such channel` を返すよう修正。

## 原因
`MsgTargetResolver::_resolveChannelToken` (`src/core/MsgTargetResolver.cpp:75`) で、channel lookup 失敗時に `MSGTARGET_RESOLVE_NO_SUCH_NICK` を返していた。呼び出し側 `PrivMsgCommand` には既に `NO_SUCH_CHANNEL` 分岐 → `errNoSuchChannel` (403) が存在するが、resolver がその enum を発火できていなかった。

## 変更内容
1 行変更のみ:
```diff
   if (channel == NULL)
-    return MSGTARGET_RESOLVE_NO_SUCH_NICK;
+    return MSGTARGET_RESOLVE_NO_SUCH_CHANNEL;
```

## Before / After
| 入力 | Before | After |
|---|---|---|
| `PRIVMSG #nonexist :hi` | `401 :No such nick/channel` | `403 :No such channel` ✅ |
| `PRIVMSG ghost :hi` | `401 :No such nick/channel` | `401 :No such nick/channel` (変わらず) |
| `PRIVMSG #real,#nonexist,ghost :m` | 全て 401 | `#nonexist` → 403、`ghost` → 401 で正しく分岐 ✅ |

## テスト
4 パターンを nc で確認:
- T1 `#nonexist` → 403 ✅
- T2 `ghost` → 401 ✅
- T3 mixed → それぞれ 403/401 正しく ✅
- T4 invalid name (`#with space`) → 403 ✅

## サブエージェントレビュー結果
LGTM。
- `MsgTargetResolver` の唯一の呼び出し元は `PrivMsgCommand` のみ (grep で確認済)
- 他の `_resolve*` メソッド (`_resolveNickOnly` / `_resolveNickMask` / `_resolveUserHost`) は nick 系リゾルバなので `NO_SUCH_NICK` 継続が正しい

## Refs
- RFC 2812 §3.3.1