### PR TITLE
fix: 新規作成チャネルの _topicProtected デフォルトを false に

### DIFF
--- a/src/domain/Channel.cpp
+++ b/src/domain/Channel.cpp
@@ -5,7 +5,8 @@ Channel::Channel(const std::string& name)
     : _name(name),
       _topic(""),
       _inviteOnly(false),
-      _topicProtected(true),
+      // RFC 2811 §4.2.1: channel flags default OFF; +t is opt-in via MODE.
+      _topicProtected(false),
       _password(""),
       _userLimit(0) {}
 


### PR DESCRIPTION
Closes #59

## 概要
新規作成された Channel の `_topicProtected` が `true` (+t) で初期化されていた問題を修正。
RFC 2811 §4.2.1 では channel flag は作成時すべて OFF がデフォルト。

## 影響 (Before)
- 新規チャネルは作成直後から `+t` 相当の状態
- 作成者 (=op) 以外の member は TOPIC 変更できない
- `MODE #chan` の応答に `+t` が含まれる (op が設定してないのに)
- reference client (irssi/HexChat) が期待する挙動と食い違う

## 変更内容
`src/domain/Channel.cpp` の 1 行のみ:
```diff
-      _topicProtected(true),
+      _topicProtected(false),
```
併せて RFC 参照の 1 行コメントを追加。

## Before / After
| 動作 | Before | After |
|---|---|---|
| 新規作成後 MODE query | `324 nick #q +t` | `324 nick #q +` ✅ |
| 新規作成直後の非 op TOPIC | `482` (拒否) | 成功 → broadcast ✅ |
| op が `MODE +t` 後の非 op TOPIC | `482` | `482` (変わらず) ✅ |

## テスト
3 パターン (T1: MODE query / T2: 非 op TOPIC / T3: +t 後の 482) すべて期待通り。

## サブエージェントレビュー結果
LGTM。
- `isTopicProtected` の consumer は `TopicCommand.cpp:32` と `ModeCommand.cpp:28` の 2 箇所のみ、いずれも新しい false デフォルトで正しく振る舞う
- Channel ctor の呼び出しは `ServerContext.cpp:99` のみ
- NIT 指摘 (コメントを英語で統一) を反映して本 commit に含めた

## Refs
- RFC 2811 §4.2.1