### PR TITLE
fix: KICK でカンマ区切り multi-target に対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ SRCS = \
 	$(SRC_DIR)/response/ReplyBuilder.cpp \
 	$(SRC_DIR)/response/ResponseSink.cpp \
 	$(SRC_DIR)/utils/HostCaseMapping.cpp \
-	$(SRC_DIR)/utils/IrcCaseMapping.cpp
+	$(SRC_DIR)/utils/IrcCaseMapping.cpp \
+	$(SRC_DIR)/utils/StringUtils.cpp
 
 OBJS = $(patsubst $(SRC_DIR)/%.cpp,$(OBJ_DIR)/%.o,$(SRCS))
 DEPS = $(OBJS:.o=.d)

--- a/include/utils/StringUtils.hpp
+++ b/include/utils/StringUtils.hpp
@@ -1,0 +1,16 @@
+#ifndef STRINGUTILS_HPP
+#define STRINGUTILS_HPP
+#include <string>
+#include <vector>
+
+namespace StringUtils {
+
+// Split `src` by `delim` into tokens.
+// Preserves empty tokens (e.g. "a,,b" → ["a", "", "b"]).
+// If `src` ends with `delim`, a trailing empty token is appended too.
+// (Callers that want to skip empties should filter the result.)
+std::vector<std::string> split(const std::string& src, char delim);
+
+}  // namespace StringUtils
+
+#endif

--- a/src/commands/JoinCommand.cpp
+++ b/src/commands/JoinCommand.cpp
@@ -1,29 +1,10 @@
 #include "JoinCommand.hpp"
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 #include "ReplyBuilder.hpp"
-
-namespace {
-std::vector<std::string> splitTargets(const std::string& rawTargets) {
-  std::vector<std::string> result;
-
-  if (rawTargets.empty())
-    return result;
-
-  std::istringstream iss(rawTargets);
-  std::string item;
-
-  while (std::getline(iss, item, ',')) {
-    result.push_back(item);
-  }
-  if (rawTargets[rawTargets.length() - 1] == ',')
-    result.push_back("");
-  return result;
-}
-}  // namespace
+#include "StringUtils.hpp"
 
 JoinCommand::JoinCommand(ServerContext& serverCtx) : _serverCtx(serverCtx) {}
 JoinCommand::~JoinCommand() {}
@@ -54,10 +35,10 @@ bool JoinCommand::execute(CommandContext& ctx) {
     return true;
   }
 
-  std::vector<std::string> chNames = splitTargets(ctx.params()[0]);
-  std::vector<std::string> keys = (ctx.params().size() > 1)
-                                      ? splitTargets(ctx.params()[1])
-                                      : splitTargets("");
+  std::vector<std::string> chNames = StringUtils::split(ctx.params()[0], ',');
+  std::vector<std::string> keys =
+      (ctx.params().size() > 1) ? StringUtils::split(ctx.params()[1], ',')
+                                : std::vector<std::string>();
 
   for (std::size_t idx = 0; idx != chNames.size(); ++idx) {
     std::string chName = chNames[idx];

--- a/src/commands/KickCommand.cpp
+++ b/src/commands/KickCommand.cpp
@@ -1,6 +1,9 @@
 #include "KickCommand.hpp"
-#include "ReplyBuilder.hpp"
 #include <iostream>
+#include <string>
+#include <vector>
+#include "ReplyBuilder.hpp"
+#include "StringUtils.hpp"
 
 KickCommand::KickCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
 KickCommand::~KickCommand() {}
@@ -11,38 +14,63 @@ bool KickCommand::execute(CommandContext &ctx) {
     return true;
   }
 
-  std::string chName = ctx.params()[0];
-  std::string targetNick = ctx.params()[1];
-  std::string reason = (ctx.params().size() > 2) ? ctx.params()[2] : targetNick;
+  std::vector<std::string> channels = StringUtils::split(ctx.params()[0], ',');
+  std::vector<std::string> users = StringUtils::split(ctx.params()[1], ',');
+  const bool hasReason = ctx.params().size() > 2;
+  const std::string reason = hasReason ? ctx.params()[2] : std::string();
 
-  Channel *channel = _serverCtx.findChannel(chName);
-  if (channel == NULL) {
-    ctx.reply(ReplyBuilder::errNoSuchChannel(ctx.nick(), chName));
-    return true;
-  }
-  if (!channel->hasMember(ctx.client())) {
-    ctx.reply(ReplyBuilder::errNotOnChannel(ctx.nick(), chName));
-    return true;
-  }
-  if (!ctx.isOperatorOf(*channel)) {
-    ctx.reply(ReplyBuilder::errChanOPrivsNeeded(ctx.nick(), chName));
+  if (channels.empty() || users.empty()) {
+    ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "KICK"));
     return true;
   }
 
-  Client *targetClient = _serverCtx.findClientByNick(targetNick);
-  if (targetClient == NULL || !channel->hasMember(*targetClient)) {
-    ctx.reply(ReplyBuilder::errUserNotInChannel(ctx.nick(), targetNick, chName));
+  // RFC 2812 §3.2.8: channels は 1 個、または users と同数でなければならない
+  // (paired form)。それ以外は不整合なので 461 を返す。
+  if (channels.size() != 1 && channels.size() != users.size()) {
+    ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "KICK"));
     return true;
   }
 
-  ctx.broadcast(*channel,
-                ":" + ctx.prefix() + " KICK " + chName + " " + targetNick +
-                    " :" + reason);
+  for (std::size_t i = 0; i < users.size(); ++i) {
+    const std::string &chName =
+        (channels.size() == 1) ? channels[0] : channels[i];
+    const std::string &targetNick = users[i];
 
-  channel->removeMember(*targetClient);
-  if (channel->getMemberCount() == 0) {
-    _serverCtx.removeChannel(chName);
-    std::cout << "[-] Channel deleted (no member): " << chName << std::endl;
+    if (chName.empty() || targetNick.empty())
+      continue;
+
+    // reason 未指定なら各 user 名をそのまま comment に使う (元実装の挙動)
+    const std::string &comment = hasReason ? reason : targetNick;
+
+    Channel *channel = _serverCtx.findChannel(chName);
+    if (channel == NULL) {
+      ctx.reply(ReplyBuilder::errNoSuchChannel(ctx.nick(), chName));
+      continue;
+    }
+    if (!channel->hasMember(ctx.client())) {
+      ctx.reply(ReplyBuilder::errNotOnChannel(ctx.nick(), chName));
+      continue;
+    }
+    if (!ctx.isOperatorOf(*channel)) {
+      ctx.reply(ReplyBuilder::errChanOPrivsNeeded(ctx.nick(), chName));
+      continue;
+    }
+
+    Client *targetClient = _serverCtx.findClientByNick(targetNick);
+    if (targetClient == NULL || !channel->hasMember(*targetClient)) {
+      ctx.reply(
+          ReplyBuilder::errUserNotInChannel(ctx.nick(), targetNick, chName));
+      continue;
+    }
+
+    ctx.broadcast(*channel, ":" + ctx.prefix() + " KICK " + chName + " " +
+                                targetNick + " :" + comment);
+
+    channel->removeMember(*targetClient);
+    if (channel->getMemberCount() == 0) {
+      _serverCtx.removeChannel(chName);
+      std::cout << "[-] Channel deleted (no member): " << chName << std::endl;
+    }
   }
 
   return true;

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -1,0 +1,24 @@
+#include "StringUtils.hpp"
+#include <sstream>
+
+namespace StringUtils {
+
+std::vector<std::string> split(const std::string& src, char delim) {
+  std::vector<std::string> result;
+
+  if (src.empty())
+    return result;
+
+  std::istringstream iss(src);
+  std::string item;
+  while (std::getline(iss, item, delim)) {
+    result.push_back(item);
+  }
+  // std::getline は末尾に delim が来た場合の trailing empty を落とすので、
+  // カンマ区切りリストで末尾要素が空文字なケースを保つために手動で追加する。
+  if (src[src.length() - 1] == delim)
+    result.push_back("");
+  return result;
+}
+
+}  // namespace StringUtils


### PR DESCRIPTION
Closes #52

## 概要
`KICK` コマンドが `channels` / `users` パラメータのカンマ区切りに対応していなかったため、`KICK #room a,b,c :bye` → 単一 nick `"a,b,c"` 扱いになる問題を修正。
RFC 2812 §3.2.8 の pairing 規則に従って動作させる。

## 変更内容

### 1. utils 追加 (issue の実装ポイントに沿う)
- `include/utils/StringUtils.hpp` / `src/utils/StringUtils.cpp` を新設
- `StringUtils::split(src, delim)` に JoinCommand の inline `splitTargets` を昇格
- Makefile SRCS に追加

### 2. JoinCommand を StringUtils::split に切り替え
挙動は完全に等価 (empty input → 空 vector、trailing delim → trailing 空要素)。

### 3. KickCommand を multi-target 対応に書き換え
- `channels` / `users` を `,` split
- pairing 規則:
  | channels count | users count | 挙動 |
  |---|---|---|
  | 1 | N | 1 channel を全 user に適用 (broadcast form) |
  | N | N | paired form (channels[i] と users[i]) |
  | それ以外 | | 461 ERR_NEEDMOREPARAMS |
- 各 pair のエラー (403/442/482/441) は `continue` で partial success
- 空 token (`u1,,u2` の中央空) は silent skip

## テスト (5 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | `KICK #r1 a1,b1,c1 :bye` | 3 KICK broadcast | ✅ |
| T2 | `KICK #r2 a2,ghost :bye` (partial) | a2 kicked, ghost → 441 | ✅ |
| T3 | `KICK #x,#y ax,by :paired` | paired 動作 | ✅ |
| T4 | `KICK #p,#q,#r a,b :bye` (mismatch) | 461 | ✅ |
| T5 | `KICK #s single :bye` (legacy) | 単一 target 動作 | ✅ |

## サブエージェントレビュー結果
LGTM (MINOR 1件 + NIT 3件、いずれも設計判断で defensible):

- **MINOR (空 token silent skip)**: 旧実装では `u1,,u2` を単一 nick として munged → 441 `u1,,u2` になっていた。新実装は空を skip し `u1` と `u2` を処理 → よりユーザーフレンドリー。
- **NIT (461 vs 407)**: mismatched counts のエラーコード、`407 ERR_TOOMANYTARGETS` は "target duplication" 用なので 461 のほうが近い。InspIRCd も 461。
- **NIT (self-kick edge case)**: op が自分を最初に kick したら以降 442、これは正しい挙動。
- **NIT (include ordering)**: repo 全体で不統一、この PR は cleaner pattern に準拠。

## Refs
- RFC 2812 §3.2.8
- Related: #53 (PART multi-channel) が同じ `StringUtils::split` を利用予定