### PR TITLE
fix: USER コマンドの invalid username を silent skip せず 461 を返す

### DIFF
--- a/src/commands/UserCommand.cpp
+++ b/src/commands/UserCommand.cpp
@@ -34,8 +34,12 @@ bool UserCommand::execute(CommandContext& ctx) {
   const std::string& realName = ctx.params()[3];
 
   if (Client::isValidUserName(userName) == false) {
-    std::cout << "Warning: USER command skipped. (invalid username: "
-              << userName << ")" << std::endl;
+    // RFC 2812 §3.1.3 は USER 用に invalid-username 専用 numeric を定義していない。
+    // ここでは "USER の引数が受理できない" 状態を汎用的に伝える 461 を返す。
+    // (silent skip だと client は登録待ちのまま無反応で hang する)
+    ctx.reply(ReplyBuilder::errNeedMoreParams("*", "USER"));
+    std::cout << "[!] USER rejected: invalid username '" << userName
+              << "' from Fd: " << ctx.client().getFd() << std::endl;
     return true;
   }
 


### PR DESCRIPTION
Closes #50

## 概要
`USER <invalid> 0 * :real` (例: `USER bad@name ...`) を受信したとき、
`UserCommand::execute` は stdout に "Warning" を出すだけで client には何も返さず、
登録待ちの client が永久 hang する問題を修正。

## 変更内容
`src/commands/UserCommand.cpp`:
- Silent skip を廃止し `461 * USER :Not enough parameters` を返す
- サーバー側 log は `[!]` タグ + `Fd: <n>` プレフィックスで既存慣習に統一

## 461 選定理由
RFC 2812 §3.1.3 は USER 用の invalid-username 専用 numeric を定義していないため、
issue 本文で提案された選択肢 (432/461/独自) のうち **461** を採用:
- 432 (ERR_ERRONEUSNICKNAME) は "Erroneous nickname" テキストで意味的に不適合
- 独自 numeric は scope creep
- 461 は "USER の引数が受理できない" という抽象的な状態として最も無害
- 主要 client (irssi/HexChat) は 461 を正しく解釈しリトライ可能

## Before / After
| 動作 | Before | After |
|---|---|---|
| `USER bad@name 0 * :Bad` | (silent) → client hang | `461 * USER :Not enough parameters` ✅ |
| その後 valid `USER good ...` | 登録できず永続 hang | recovery して 001 welcome ✅ |
| Server-side log | `Warning: USER command skipped.` | `[!] USER rejected: invalid username 'bad@name' from Fd: 4` |

## テスト (3 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | `USER bad@name` | 461 | ✅ |
| T2 | invalid → valid USER で recovery | 461 → 001 | ✅ |
| T3 | valid USER (backward compat) | 001 | ✅ |

## サブエージェントレビュー結果
LGTM (NIT 2件のうち 1件 log format 統一を本 PR に反映済):
- `[!]` タグと `Fd:` プレフィックスを既存 `Server.cpp:184` 等と揃えた
- もう 1 件 (461 の text が "too few params" と重複) は defensible なので defer

## Refs
- RFC 2812 §3.1.3