### PR TITLE
fix: MODE 未知フラグ検出時も既知フラグを反映する partial success

### DIFF
--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -56,8 +56,6 @@ bool ModeCommand::execute(CommandContext &ctx) {
   size_t paramIndex = 2;
   std::string modeParams;
 
-  // 実際に適用できた flag のみを appliedMode として蓄積し、最後に一度だけ
-  // broadcast する。未知 flag に当たっても既知 flag は反映を続ける (#60)。
   std::string appliedMode;
   char lastAppliedSign = 0;
 
@@ -146,7 +144,6 @@ bool ModeCommand::execute(CommandContext &ctx) {
     }
   }
 
-  // 何一つ適用できなかった (全部 unknown flag) 場合は broadcast しない。
   if (!appliedMode.empty()) {
     ctx.broadcast(*channel,
                   ":" + ctx.prefix() + " MODE " + chName + " " + appliedMode +

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -56,6 +56,11 @@ bool ModeCommand::execute(CommandContext &ctx) {
   size_t paramIndex = 2;
   std::string modeParams;
 
+  // 実際に適用できた flag のみを appliedMode として蓄積し、最後に一度だけ
+  // broadcast する。未知 flag に当たっても既知 flag は反映を続ける (#60)。
+  std::string appliedMode;
+  char lastAppliedSign = 0;
+
   for (size_t i = 0; i < mode.size(); ++i) {
     char flag = mode[i];
 
@@ -68,10 +73,14 @@ bool ModeCommand::execute(CommandContext &ctx) {
       continue;
     }
 
+    bool applied = false;
+
     if (flag == 'i') {
       channel->setInviteOnly(adding);
+      applied = true;
     } else if (flag == 't') {
       channel->setTopicProtected(adding);
+      applied = true;
     } else if (flag == 'k') {
       if (adding) {
         if (ctx.params().size() <= paramIndex) {
@@ -87,6 +96,7 @@ bool ModeCommand::execute(CommandContext &ctx) {
       } else {
         channel->setPassword("");
       }
+      applied = true;
     } else if (flag == 'o') {
       if (ctx.params().size() <= paramIndex) {
         ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "MODE"));
@@ -108,6 +118,7 @@ bool ModeCommand::execute(CommandContext &ctx) {
       else
         channel->removeOperator(*targetClient);
       modeParams += " " + targetNick;
+      applied = true;
     } else if (flag == 'l') {
       if (adding) {
         if (ctx.params().size() <= paramIndex) {
@@ -119,14 +130,27 @@ bool ModeCommand::execute(CommandContext &ctx) {
       } else {
         channel->setUserLimit(0);
       }
+      applied = true;
     } else {
       ctx.reply(ReplyBuilder::errUnknownMode(ctx.nick(), flag, chName));
-      return true;
+      continue;
+    }
+
+    if (applied) {
+      char sign = adding ? '+' : '-';
+      if (sign != lastAppliedSign) {
+        appliedMode += sign;
+        lastAppliedSign = sign;
+      }
+      appliedMode += flag;
     }
   }
 
-  ctx.broadcast(*channel,
-                ":" + ctx.prefix() + " MODE " + chName + " " + mode +
-                    modeParams);
+  // 何一つ適用できなかった (全部 unknown flag) 場合は broadcast しない。
+  if (!appliedMode.empty()) {
+    ctx.broadcast(*channel,
+                  ":" + ctx.prefix() + " MODE " + chName + " " + appliedMode +
+                      modeParams);
+  }
   return true;
 }


### PR DESCRIPTION
Closes #60

## 概要
`MODE #x +ita` のように未知フラグが混じっていた場合、`+i` `+t` は既に channel state に反映されたにもかかわらず、未知の `a` で `return true` してしまい **MODE broadcast が送られない** 問題を修正。

## 変更内容
`src/commands/ModeCommand.cpp`:
- 未知 flag branch を `return true` → `continue` に変更
- 実効フラグ列 `appliedMode` と `modeParams` を蓄積、ループ後に一度だけ broadcast
- sign (`+`/`-`) は直前と異なる時のみ append (`+it-l` のように redundant sign を避ける)
- 何も適用できなかった (all unknown) 場合は broadcast 自体をスキップ

## Before / After
| 入力 | Before | After |
|---|---|---|
| `MODE #x +ita` | 472 のみ、broadcast なし (でも state は変更済) | 472 + `:sender MODE #x +it` ✅ |
| `MODE #x +itxy-l` | 472 for x で abort | 472 for x/y + `:sender MODE #x +it-l` ✅ |
| `MODE #x +xy` | 472 for x で abort | 472 for x/y、broadcast なし ✅ |
| `MODE #x +i` | broadcast `+i` | broadcast `+i` (変わらず) ✅ |

## テスト
4 パターン (partial apply / mixed sign / all-unknown / backward compat) を検証。

## サブエージェントレビュー結果
LGTM。sign tracking、paramIndex bookkeeping、query branch 無影響を確認。

**follow-up 候補 (別 issue で起票予定):** `+k` errKeySet / `+o` errNoSuchNick 等の他 `return true` 路も同種の "state 変更後 broadcast されず" 問題を残している (pre-existing、本 PR 対象外)。

## Refs
- RFC 2812 §3.2.3