### PR TITLE
fix: QUIT 受信時に切断 client 自身へ ERROR :Closing Link を返す

### DIFF
--- a/src/commands/QuitCommand.cpp
+++ b/src/commands/QuitCommand.cpp
@@ -4,7 +4,15 @@ QuitCommand::QuitCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
 QuitCommand::~QuitCommand() {}
 
 bool QuitCommand::execute(CommandContext &ctx) {
-  std::string quitMsg = (ctx.params().empty()) ? "Client Quit" : ctx.params()[0];
-  _serverCtx.removeClientFromAllChannels(ctx.client(), quitMsg);
+  std::string reason =
+      (ctx.params().empty()) ? "Client Quit" : ctx.params()[0];
+
+  // RFC 2812 §3.7.4: 切断する client 自身に ERROR :Closing Link を返してから
+  // 切断する。send buffer に積むだけで、実際の flush は Server 側の
+  // _disconnectClient が close の直前に行う。
+  ctx.reply("ERROR :Closing Link: " + ctx.client().getHost() + " (Quit: " +
+            reason + ")");
+
+  _serverCtx.removeClientFromAllChannels(ctx.client(), reason);
   return false;
 }

--- a/src/commands/QuitCommand.cpp
+++ b/src/commands/QuitCommand.cpp
@@ -7,9 +7,6 @@ bool QuitCommand::execute(CommandContext &ctx) {
   std::string reason =
       (ctx.params().empty()) ? "Client Quit" : ctx.params()[0];
 
-  // RFC 2812 §3.7.4: 切断する client 自身に ERROR :Closing Link を返してから
-  // 切断する。send buffer に積むだけで、実際の flush は Server 側の
-  // _disconnectClient が close の直前に行う。
   ctx.reply("ERROR :Closing Link: " + ctx.client().getHost() + " (Quit: " +
             reason + ")");
 

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -307,6 +307,11 @@ void Server::_registerClient(int clientFd, const std::string &host) {
 void Server::_disconnectClient(size_t &index, const std::string &quitMsg) {
   int fd = _pollFds[index].fd;
   _serverCtx.removeClientFromAllChannels(*_clients[fd], quitMsg);
+  // close する前に best-effort で send buffer を吐き出す。QuitCommand が積んだ
+  // ERROR :Closing Link や、直前に応答した numeric を client に届けるため。
+  // 非 blocking send の 1 回きり呼び出しなので、socket が既に死んでいれば
+  // 素通り (kernel が握りつぶす) だけで済む。
+  _flushSendBuffer(index);
   delete _clients[fd];
   _clients.erase(fd);
   _pollFds.erase(_pollFds.begin() + index);

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -307,10 +307,6 @@ void Server::_registerClient(int clientFd, const std::string &host) {
 void Server::_disconnectClient(size_t &index, const std::string &quitMsg) {
   int fd = _pollFds[index].fd;
   _serverCtx.removeClientFromAllChannels(*_clients[fd], quitMsg);
-  // close する前に best-effort で send buffer を吐き出す。QuitCommand が積んだ
-  // ERROR :Closing Link や、直前に応答した numeric を client に届けるため。
-  // 非 blocking send の 1 回きり呼び出しなので、socket が既に死んでいれば
-  // 素通り (kernel が握りつぶす) だけで済む。
   _flushSendBuffer(index);
   delete _clients[fd];
   _clients.erase(fd);


### PR DESCRIPTION
Closes #63

## 概要
`QUIT :bye` を受信した client 自身に `ERROR :Closing Link` 応答が返らず、
そのまま TCP close されていた問題を修正。RFC 2812 §3.7.4 準拠。

## 変更内容

### 1. `src/commands/QuitCommand.cpp`
- 実行者に `ERROR :Closing Link: <host> (Quit: <reason>)` を `ctx.reply` で積む
- local 変数 `quitMsg` → `reason` にリネーム (意味を明確化)

### 2. `src/core/Server.cpp::_disconnectClient`
- `delete _clients[fd]` の直前に `_flushSendBuffer(index)` を呼ぶ
- QuitCommand が積んだ ERROR や、直前の numeric 応答を close 前に wire に流す
- SIGPIPE は既に SIG_IGN 済 → 死んだ socket でも安全に best-effort

## Before / After
```
QUIT :goodbye all
```
| | Before | After |
|---|---|---|
| 送信者応答 | (無し) | `ERROR :Closing Link: 127.0.0.1 (Quit: goodbye all)` ✅ |
| 他 member への QUIT broadcast | (raw reason 文字列のまま送出、PR #46 のスコープ) | 同左 (本 PR ではフォーマット変更しない) |

## テスト (4 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | `QUIT :goodbye all` | `ERROR ... (Quit: goodbye all)` | ✅ |
| T2 | `QUIT` (no reason) | `ERROR ... (Quit: Client Quit)` | ✅ |
| T3 | 2 client 同 channel で alice QUIT | alice に ERROR、bob に broadcast | ✅ |
| T4 | TCP close (nc timeout) | client 側は既に消えているので届かず (期待通り) | ✅ |

## サブエージェントレビュー結果
**LGTM 指摘なし**。
- Flush ordering (delete の直前) 正しい
- SIGPIPE `SIG_IGN` で dead socket への send も安全
- QuitCommand → Server の 2 段階 `removeClientFromAllChannels` は 2 回目が no-op (double broadcast なし)
- PR #46 (QUIT broadcast format) と conflict なし: 両 PR とも `reason` 変数へ収束

## Refs
- RFC 2812 §3.7.4
- Related: PR #46 (QUIT の other-member 向け broadcast フォーマット、別スコープ)