### PR TITLE
feat: IRCv3 CAP コマンドの最小実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SRCS = \
 	$(SRC_DIR)/core/Server.cpp \
 	$(SRC_DIR)/core/ServerContext.cpp \
 	$(SRC_DIR)/commands/ACommand.cpp \
+	$(SRC_DIR)/commands/CapCommand.cpp \
 	$(SRC_DIR)/commands/InviteCommand.cpp \
 	$(SRC_DIR)/commands/JoinCommand.cpp \
 	$(SRC_DIR)/commands/KickCommand.cpp \

--- a/include/commands/CapCommand.hpp
+++ b/include/commands/CapCommand.hpp
@@ -4,9 +4,6 @@
 #include "ACommand.hpp"
 #include "ServerContext.hpp"
 
-// IRCv3 CAP handshake の最小実装。
-// 本サーバは IRCv3 拡張を一切サポートしないため、常に空 capability list を
-// 返して client の登録シーケンスを妨げないことだけを目的とする。
 class CapCommand : public ACommand {
  private:
   ServerContext &_serverCtx;

--- a/include/commands/CapCommand.hpp
+++ b/include/commands/CapCommand.hpp
@@ -1,0 +1,24 @@
+#ifndef CAPCOMMAND_HPP
+#define CAPCOMMAND_HPP
+
+#include "ACommand.hpp"
+#include "ServerContext.hpp"
+
+// IRCv3 CAP handshake の最小実装。
+// 本サーバは IRCv3 拡張を一切サポートしないため、常に空 capability list を
+// 返して client の登録シーケンスを妨げないことだけを目的とする。
+class CapCommand : public ACommand {
+ private:
+  ServerContext &_serverCtx;
+
+  CapCommand(const CapCommand &other);
+  CapCommand &operator=(const CapCommand &other);
+
+ public:
+  CapCommand(ServerContext &serverCtx);
+  virtual ~CapCommand();
+
+  virtual bool execute(CommandContext &ctx);
+};
+
+#endif

--- a/src/commands/CapCommand.cpp
+++ b/src/commands/CapCommand.cpp
@@ -4,31 +4,19 @@ CapCommand::CapCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
 CapCommand::~CapCommand() {}
 
 bool CapCommand::execute(CommandContext &ctx) {
-  // 登録前でも受け付ける (IRCv3): dispatcher の pre-registration list に
-  // CAP が入っている前提。ここでは subcommand ごとに最小応答を返す。
-  //
-  // target は client の nick が確定していれば nick、未確定なら "*"。
-  // 三項演算子の両辺を統一するため値で受ける (const-ref だと一方が
-  // 一時オブジェクトになり、後々のリファクタで dangling を招きうる)。
   std::string target = ctx.nick().empty() ? "*" : ctx.nick();
 
   if (ctx.params().empty()) {
-    // 引数無し → 何もせず戻す (無害な no-op)
     return true;
   }
 
   const std::string &sub = ctx.params()[0];
 
   if (sub == "LS") {
-    // capability list を持たないので常に空を返す
     ctx.reply("CAP " + target + " LS :");
   } else if (sub == "LIST") {
-    // client が有効化した capability list も空
     ctx.reply("CAP " + target + " LIST :");
   } else if (sub == "REQ") {
-    // どの拡張も提供しないため NAK で返す。IRCv3 は :cap1 cap2 trailing 形式を
-    // 想定するが、非 trailing の `CAP REQ cap1 cap2` にも耐えるよう
-    // params[1..] を空白 join して echo する。
     std::string requested;
     for (std::size_t i = 1; i < ctx.params().size(); ++i) {
       if (!requested.empty())
@@ -37,8 +25,5 @@ bool CapCommand::execute(CommandContext &ctx) {
     }
     ctx.reply("CAP " + target + " NAK :" + requested);
   }
-  // CAP END / 未知 subcommand は silent。
-  // 厳密には未知 subcommand は 410 ERR_INVALIDCAPCMD が推奨 (IRCv3) だが、
-  // silent の方が寛容な client 実装に馴染むためこれを採用する。
   return true;
 }

--- a/src/commands/CapCommand.cpp
+++ b/src/commands/CapCommand.cpp
@@ -1,0 +1,44 @@
+#include "CapCommand.hpp"
+
+CapCommand::CapCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
+CapCommand::~CapCommand() {}
+
+bool CapCommand::execute(CommandContext &ctx) {
+  // 登録前でも受け付ける (IRCv3): dispatcher の pre-registration list に
+  // CAP が入っている前提。ここでは subcommand ごとに最小応答を返す。
+  //
+  // target は client の nick が確定していれば nick、未確定なら "*"。
+  // 三項演算子の両辺を統一するため値で受ける (const-ref だと一方が
+  // 一時オブジェクトになり、後々のリファクタで dangling を招きうる)。
+  std::string target = ctx.nick().empty() ? "*" : ctx.nick();
+
+  if (ctx.params().empty()) {
+    // 引数無し → 何もせず戻す (無害な no-op)
+    return true;
+  }
+
+  const std::string &sub = ctx.params()[0];
+
+  if (sub == "LS") {
+    // capability list を持たないので常に空を返す
+    ctx.reply("CAP " + target + " LS :");
+  } else if (sub == "LIST") {
+    // client が有効化した capability list も空
+    ctx.reply("CAP " + target + " LIST :");
+  } else if (sub == "REQ") {
+    // どの拡張も提供しないため NAK で返す。IRCv3 は :cap1 cap2 trailing 形式を
+    // 想定するが、非 trailing の `CAP REQ cap1 cap2` にも耐えるよう
+    // params[1..] を空白 join して echo する。
+    std::string requested;
+    for (std::size_t i = 1; i < ctx.params().size(); ++i) {
+      if (!requested.empty())
+        requested += " ";
+      requested += ctx.params()[i];
+    }
+    ctx.reply("CAP " + target + " NAK :" + requested);
+  }
+  // CAP END / 未知 subcommand は silent。
+  // 厳密には未知 subcommand は 410 ERR_INVALIDCAPCMD が推奨 (IRCv3) だが、
+  // silent の方が寛容な client 実装に馴染むためこれを採用する。
+  return true;
+}

--- a/src/core/CommandDispatcher.cpp
+++ b/src/core/CommandDispatcher.cpp
@@ -1,4 +1,5 @@
 #include "CommandDispatcher.hpp"
+#include "CapCommand.hpp"
 #include "InviteCommand.hpp"
 #include "JoinCommand.hpp"
 #include "KickCommand.hpp"
@@ -28,6 +29,7 @@ CommandDispatcher::CommandDispatcher(ServerContext &serverCtx)
   _commands["INVITE"] = new InviteCommand(_serverCtx);
   _commands["MODE"] = new ModeCommand(_serverCtx);
   _commands["PING"] = new PingCommand(_serverCtx);
+  _commands["CAP"] = new CapCommand(_serverCtx);
 }
 
 CommandDispatcher::~CommandDispatcher() {
@@ -40,7 +42,7 @@ CommandDispatcher::~CommandDispatcher() {
 bool CommandDispatcher::_isPreRegistrationCommand(
     const std::string &command) const {
   return command == "PASS" || command == "NICK" || command == "USER" ||
-         command == "QUIT";
+         command == "QUIT" || command == "CAP";
 }
 
 bool CommandDispatcher::dispatch(CommandContext &ctx) {


### PR DESCRIPTION
Closes #62

## 概要
irssi/HexChat 等の modern client が接続直後に送る `CAP LS 302` を、
現状の dispatcher が `451 :You have not registered` で拒否してしまう問題を修正。
IRCv3 CAP コマンドを最小実装し、pre-registration list に追加。

## 変更内容

### 新規ファイル
- `include/commands/CapCommand.hpp` + `src/commands/CapCommand.cpp`
  - `CAP LS`   → `CAP <target> LS :` (空 capability list)
  - `CAP LIST` → `CAP <target> LIST :`
  - `CAP REQ`  → `CAP <target> NAK :<requested>` (拡張未サポート)
  - `CAP END` / 未知 subcommand → silent

### 既存ファイル
- `Makefile` — SRCS に CapCommand.cpp を追加
- `src/core/CommandDispatcher.cpp` — CAP を command map と _isPreRegistrationCommand に登録

## Before / After
| 送信 | Before | After |
|---|---|---|
| `CAP LS 302` | `451 * :You have not registered` | `CAP * LS :` ✅ |
| `CAP REQ :multi-prefix` | 451 | `CAP * NAK :multi-prefix` ✅ |
| `CAP LIST` (登録後) | `421 CAP :Unknown command` | `CAP <nick> LIST :` ✅ |
| `JOIN #foo` (未登録) | `451` | `451` (変わらず、CAP 以外は保護維持) ✅ |

## テスト (4 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | irssi の CAP LS + PASS+NICK+USER+CAP END | LS 応答 → 001 | ✅ |
| T2 | CAP REQ を含むフロー | NAK → 001 | ✅ |
| T3 | 登録後の CAP LIST | 空 LIST 応答 | ✅ |
| T4 | pre-reg JOIN (CAP 以外) | 451 変わらず | ✅ |

## サブエージェントレビュー結果
LGTM。指摘 MINOR 3件・NIT 3件のうち 2件を本 PR に反映:
- **反映** [MINOR] 三項演算子の const-ref が temporary を捕まえる問題 → `std::string target = ...` 値受けに
- **反映** [MINOR] `CAP REQ cap1 cap2` (非 trailing 形式) が params[1] だけ echo → params[1..] を空白 join
- **defer** [MINOR] `CAP END` が届くまで registration を保留すべき → Client state 追加が必要、follow-up 候補
- NITs (コメント配置、410 ERR_INVALIDCAPCMD の言及、tab スタイル) は言及のみで対応不要

## Refs
- IRCv3 Capability Negotiation: https://ircv3.net/specs/extensions/capability-negotiation.html