### PR TITLE
feat: MODE <nick> (user mode) の最小実装

### DIFF
--- a/include/commands/ModeCommand.hpp
+++ b/include/commands/ModeCommand.hpp
@@ -11,6 +11,8 @@ private:
 	ModeCommand(const ModeCommand &other);
 	ModeCommand &operator=(const ModeCommand &other);
 
+	bool _executeUserMode(CommandContext &ctx, const std::string &target);
+
 public:
 	ModeCommand(ServerContext &serverCtx);
 	virtual ~ModeCommand();

--- a/include/domain/Client.hpp
+++ b/include/domain/Client.hpp
@@ -79,7 +79,6 @@ class Client {
   std::string getPrefix() const;
 
   // User mode helpers
-  // "+iw" のように set 済み flag を並べた文字列を返す (無い場合 "+")。
   std::string getModeString() const;
 };
 

--- a/include/domain/Client.hpp
+++ b/include/domain/Client.hpp
@@ -73,9 +73,14 @@ class Client {
   void setUserName(const std::string& userName);
   void setRealName(const std::string& realName);
   void addMode(UserMode mode);
+  void removeMode(UserMode mode);
   void setPassChecked(bool status);
   void setRegistered(bool status);
   std::string getPrefix() const;
+
+  // User mode helpers
+  // "+iw" のように set 済み flag を並べた文字列を返す (無い場合 "+")。
+  std::string getModeString() const;
 };
 
 #endif

--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -14,6 +14,8 @@ class ReplyBuilder {
  public:
   static std::string rplWelcome(const std::string& clientName,
                                 const std::string& clientPrefix);
+  static std::string rplUmodeIs(const std::string& clientName,
+                                const std::string& mode);
   static std::string rplChannelModeIs(const std::string& clientName,
                                       const std::string& channelName,
                                       const std::string& mode,
@@ -72,6 +74,8 @@ class ReplyBuilder {
                                        const std::string& channelName);
   static std::string errKeySet(const std::string& channelName);
   static std::string errIncorrectPassword();
+  static std::string errUsersDontMatch(const std::string& clientName);
+  static std::string errUmodeUnknownFlag(const std::string& clientName);
 };
 
 #endif

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -1,10 +1,105 @@
 #include "ModeCommand.hpp"
-#include "ReplyBuilder.hpp"
 #include <cstdlib>
 #include <sstream>
+#include "IrcCaseMapping.hpp"
+#include "ReplyBuilder.hpp"
 
 ModeCommand::ModeCommand(ServerContext &serverCtx) : _serverCtx(serverCtx) {}
 ModeCommand::~ModeCommand() {}
+
+namespace {
+
+// User mode 1 文字 → enum マッピング。未知 flag は UMODE_NONE を返す。
+UserMode userModeFromChar(char c) {
+  switch (c) {
+    case 'i':
+      return UMODE_INVIS;
+    case 'w':
+      return UMODE_WALLO;
+    case 's':
+      return UMODE_SNICE;
+    case 'r':
+      return UMODE_RESTR;
+    case 'o':
+      return UMODE_OPER;
+    case 'O':
+      return UMODE_LOPER;
+    case 'a':
+      return UMODE_AWAY;
+    default:
+      return UMODE_NONE;
+  }
+}
+
+// User が直接 set できない mode (OPER/AWAY 等はサーバー側発行のみ)
+bool isSelfSettable(char c) {
+  return c == 'i' || c == 'w' || c == 's' || c == 'r';
+}
+
+// User が直接 unset できない mode (r は一度 set したら解除不可 RFC 2812)
+bool isSelfUnsettable(char c) {
+  return c == 'i' || c == 'w' || c == 's' || c == 'o' || c == 'O' || c == 'a';
+}
+
+}  // namespace
+
+// User mode コマンド (MODE <selfnick> [mode]) の処理。
+// target が自分以外なら 502 ERR_USERSDONTMATCH を返す。
+bool ModeCommand::_executeUserMode(CommandContext &ctx,
+                                   const std::string &target) {
+  if (!IrcCaseMapping::equals(target, ctx.nick())) {
+    ctx.reply(ReplyBuilder::errUsersDontMatch(ctx.nick()));
+    return true;
+  }
+
+  // Query: mode 引数無し → 現在の user mode を 221 で返す
+  if (ctx.params().size() == 1) {
+    ctx.reply(
+        ReplyBuilder::rplUmodeIs(ctx.nick(), ctx.client().getModeString()));
+    return true;
+  }
+
+  // Modification
+  const std::string &mode = ctx.params()[1];
+  bool adding = true;
+  bool sawUnknown = false;
+
+  for (std::size_t i = 0; i < mode.size(); ++i) {
+    char flag = mode[i];
+    if (flag == '+') {
+      adding = true;
+      continue;
+    }
+    if (flag == '-') {
+      adding = false;
+      continue;
+    }
+
+    UserMode um = userModeFromChar(flag);
+    if (um == UMODE_NONE) {
+      sawUnknown = true;
+      continue;
+    }
+
+    if (adding) {
+      if (isSelfSettable(flag))
+        ctx.client().addMode(um);
+      // 'o'/'O'/'a' の set は OPER/AWAY コマンド専用 → silent ignore
+    } else {
+      if (isSelfUnsettable(flag))
+        ctx.client().removeMode(um);
+      // 'r' の unset は RFC 上不可 → silent ignore
+    }
+  }
+
+  if (sawUnknown)
+    ctx.reply(ReplyBuilder::errUmodeUnknownFlag(ctx.nick()));
+
+  // 変更後の状態を自身にエコー
+  ctx.reply(":" + ctx.prefix() + " MODE " + ctx.nick() + " :" +
+            ctx.client().getModeString());
+  return true;
+}
 
 bool ModeCommand::execute(CommandContext &ctx) {
   if (ctx.params().empty()) {
@@ -13,6 +108,11 @@ bool ModeCommand::execute(CommandContext &ctx) {
   }
 
   std::string chName = ctx.params()[0];
+
+  // Channel prefix でなければ user mode コマンドとして処理する。
+  if (chName.empty() || !Channel::isChannelPrefix(chName[0]))
+    return _executeUserMode(ctx, chName);
+
   Channel *channel = _serverCtx.findChannel(chName);
   if (channel == NULL) {
     ctx.reply(ReplyBuilder::errNoSuchChannel(ctx.nick(), chName));

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -9,7 +9,6 @@ ModeCommand::~ModeCommand() {}
 
 namespace {
 
-// User mode 1 文字 → enum マッピング。未知 flag は UMODE_NONE を返す。
 UserMode userModeFromChar(char c) {
   switch (c) {
     case 'i':
@@ -31,20 +30,16 @@ UserMode userModeFromChar(char c) {
   }
 }
 
-// User が直接 set できない mode (OPER/AWAY 等はサーバー側発行のみ)
 bool isSelfSettable(char c) {
   return c == 'i' || c == 'w' || c == 's' || c == 'r';
 }
 
-// User が直接 unset できない mode (r は一度 set したら解除不可 RFC 2812)
 bool isSelfUnsettable(char c) {
   return c == 'i' || c == 'w' || c == 's' || c == 'o' || c == 'O' || c == 'a';
 }
 
 }  // namespace
 
-// User mode コマンド (MODE <selfnick> [mode]) の処理。
-// target が自分以外なら 502 ERR_USERSDONTMATCH を返す。
 bool ModeCommand::_executeUserMode(CommandContext &ctx,
                                    const std::string &target) {
   if (!IrcCaseMapping::equals(target, ctx.nick())) {
@@ -52,14 +47,12 @@ bool ModeCommand::_executeUserMode(CommandContext &ctx,
     return true;
   }
 
-  // Query: mode 引数無し → 現在の user mode を 221 で返す
   if (ctx.params().size() == 1) {
     ctx.reply(
         ReplyBuilder::rplUmodeIs(ctx.nick(), ctx.client().getModeString()));
     return true;
   }
 
-  // Modification
   const std::string &mode = ctx.params()[1];
   bool adding = true;
   bool sawUnknown = false;
@@ -84,18 +77,15 @@ bool ModeCommand::_executeUserMode(CommandContext &ctx,
     if (adding) {
       if (isSelfSettable(flag))
         ctx.client().addMode(um);
-      // 'o'/'O'/'a' の set は OPER/AWAY コマンド専用 → silent ignore
     } else {
       if (isSelfUnsettable(flag))
         ctx.client().removeMode(um);
-      // 'r' の unset は RFC 上不可 → silent ignore
     }
   }
 
   if (sawUnknown)
     ctx.reply(ReplyBuilder::errUmodeUnknownFlag(ctx.nick()));
 
-  // 変更後の状態を自身にエコー
   ctx.reply(":" + ctx.prefix() + " MODE " + ctx.nick() + " :" +
             ctx.client().getModeString());
   return true;
@@ -109,7 +99,6 @@ bool ModeCommand::execute(CommandContext &ctx) {
 
   std::string chName = ctx.params()[0];
 
-  // Channel prefix でなければ user mode コマンドとして処理する。
   if (chName.empty() || !Channel::isChannelPrefix(chName[0]))
     return _executeUserMode(ctx, chName);
 

--- a/src/domain/Client.cpp
+++ b/src/domain/Client.cpp
@@ -171,6 +171,27 @@ void Client::setRealName(const std::string& realName) {
 void Client::addMode(UserMode mode) {
   _mode |= static_cast<unsigned int>(mode);
 }
+void Client::removeMode(UserMode mode) {
+  _mode &= ~static_cast<unsigned int>(mode);
+}
+std::string Client::getModeString() const {
+  std::string result = "+";
+  if (_mode & UMODE_INVIS)
+    result += "i";
+  if (_mode & UMODE_WALLO)
+    result += "w";
+  if (_mode & UMODE_OPER)
+    result += "o";
+  if (_mode & UMODE_LOPER)
+    result += "O";
+  if (_mode & UMODE_AWAY)
+    result += "a";
+  if (_mode & UMODE_RESTR)
+    result += "r";
+  if (_mode & UMODE_SNICE)
+    result += "s";
+  return result;
+}
 void Client::setPassChecked(bool status) {
   _isPassChecked = status;
 }

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -6,6 +6,11 @@ std::string ReplyBuilder::rplWelcome(const std::string& clientName,
          clientPrefix;
 }
 
+std::string ReplyBuilder::rplUmodeIs(const std::string& clientName,
+                                     const std::string& mode) {
+  return "221 " + clientName + " " + mode;
+}
+
 std::string ReplyBuilder::rplChannelModeIs(const std::string& clientName,
                                            const std::string& channelName,
                                            const std::string& mode,
@@ -163,4 +168,12 @@ std::string ReplyBuilder::errChanOPrivsNeeded(const std::string& clientName,
                                               const std::string& channelName) {
   return "482 " + clientName + " " + channelName +
          " :You're not channel operator";
+}
+
+std::string ReplyBuilder::errUsersDontMatch(const std::string& clientName) {
+  return "502 " + clientName + " :Cannot change mode for other users";
+}
+
+std::string ReplyBuilder::errUmodeUnknownFlag(const std::string& clientName) {
+  return "501 " + clientName + " :Unknown MODE flag";
 }


### PR DESCRIPTION
Closes #61

## 概要
`MODE alice` (自分の nick 対象の MODE query) が `403 :No such channel` を返していた。RFC 2812 §3.1.5 に従い user mode コマンドとして処理する。

## 変更内容

### `Client` (`include/domain/Client.hpp` + `src/domain/Client.cpp`)
- `void removeMode(UserMode)` を追加
- `std::string getModeString() const` を追加 (set 済み flag を "+iw..." 形式で返す)

### `ReplyBuilder` (`include/response/ReplyBuilder.hpp` + `src/response/ReplyBuilder.cpp`)
- `rplUmodeIs(nick, mode)` → `221 <nick> <mode>`
- `errUsersDontMatch(nick)` → `502 <nick> :Cannot change mode for other users`
- `errUmodeUnknownFlag(nick)` → `501 <nick> :Unknown MODE flag`

### `ModeCommand` (`include/commands/ModeCommand.hpp` + `src/commands/ModeCommand.cpp`)
- 先頭に prefix 判定を追加: `Channel::isChannelPrefix(chName[0])` でなければ user mode branch へ
- 匿名 namespace に helper (`userModeFromChar` / `isSelfSettable` / `isSelfUnsettable`)
- `_executeUserMode`:
  - target 他人 → 502
  - target 自身 & 引数無し → 221 で現在のモード返却
  - target 自身 & 引数あり → i/w/s add-only、i/w/s/o/O/a remove、r は set のみ (RFC)
    - `+o/+O/+a` set は silent ignore (OPER/AWAY コマンド専用)
    - 未知 flag → 501
  - 変更後、`:prefix MODE nick :<state>` で自身にエコー

## テスト (7 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | `MODE a` (query, 未設定) | `221 a +` | ✅ |
| T2 | `MODE b +i` → `MODE b` | echo + `221 b +i` | ✅ |
| T3 | `MODE c +iw-i` | 適用後 `+w` | ✅ |
| T4 | `MODE d +o` (self-elevate) | silent skip、state `+` | ✅ |
| T5 | `MODE alice` from bob | `502 bob :Cannot change mode...` | ✅ |
| T6 | `MODE e +xy` (unknown) | `501 :Unknown MODE flag` | ✅ |
| T7 | `MODE #x +i` (channel MODE) | backward compat 動作 | ✅ |

## サブエージェントレビュー結果
LGTM。指摘:
- **反映** [MINOR] `getMode()` 未使用の dead code → 削除
- **defer** [NIT] 変更ゼロの場合の echo が redundant → 実害小さいので defer
- **defer** [NIT] 空 state の `+` 表記 (`""` の方が真の ircd 慣習に近い) → RFC 許容範囲、interop 問題なし
- **defer** [NIT] `MODE :` (空 target) が 502 に流れる → parser が空 middle param 出さないため実質到達不能

## Refs
- RFC 2812 §3.1.5 (User mode)
- RFC 2812 §5.1 (RPL_UMODEIS 221)
- RFC 2812 §5.2 (ERR_UMODEUNKNOWNFLAG 501, ERR_USERSDONTMATCH 502)