### PR TITLE
fix: numeric reply / server 発 message に server prefix を自動付与

### DIFF
--- a/include/response/ResponseSink.hpp
+++ b/include/response/ResponseSink.hpp
@@ -22,11 +22,7 @@ public:
 
   const std::string &getServerName() const;
 
-  // reply() は「サーバー発の応答」用。msg が ":" prefix を持たない場合
-  // 自動的に ":<serverName> " を先頭に付与する (RFC 2812 §2.3)。
   void reply(Client &client, const std::string &msg);
-  // direct/broadcast は「他 client の行為を中継」用。msg は既に
-  // ":nick!user@host CMD ..." 形式で来る前提のため prefix は付与しない。
   void direct(Client &client, const std::string &msg);
   void broadcast(Channel &channel, const std::string &msg);
   void broadcastExcept(Channel &channel, const std::string &msg,

--- a/include/response/ResponseSink.hpp
+++ b/include/response/ResponseSink.hpp
@@ -8,6 +8,8 @@ class Channel;
 
 class ResponseSink {
 private:
+  std::string _serverName;
+
   ResponseSink(const ResponseSink &other);
   ResponseSink &operator=(const ResponseSink &other);
 
@@ -15,9 +17,16 @@ private:
 
 public:
   ResponseSink();
+  explicit ResponseSink(const std::string &serverName);
   ~ResponseSink();
 
+  const std::string &getServerName() const;
+
+  // reply() は「サーバー発の応答」用。msg が ":" prefix を持たない場合
+  // 自動的に ":<serverName> " を先頭に付与する (RFC 2812 §2.3)。
   void reply(Client &client, const std::string &msg);
+  // direct/broadcast は「他 client の行為を中継」用。msg は既に
+  // ":nick!user@host CMD ..." 形式で来る前提のため prefix は付与しない。
   void direct(Client &client, const std::string &msg);
   void broadcast(Channel &channel, const std::string &msg);
   void broadcastExcept(Channel &channel, const std::string &msg,

--- a/src/response/ResponseSink.cpp
+++ b/src/response/ResponseSink.cpp
@@ -2,15 +2,29 @@
 #include "Channel.hpp"
 #include "Client.hpp"
 
-ResponseSink::ResponseSink() {}
+ResponseSink::ResponseSink() : _serverName("ircserv") {}
+ResponseSink::ResponseSink(const std::string &serverName)
+    : _serverName(serverName) {}
 ResponseSink::~ResponseSink() {}
+
+const std::string &ResponseSink::getServerName() const {
+  return _serverName;
+}
 
 void ResponseSink::_appendLine(Client &client, const std::string &msg) {
   client.appendSendBuffer(msg + "\r\n");
 }
 
 void ResponseSink::reply(Client &client, const std::string &msg) {
-  _appendLine(client, msg);
+  // 空文字列は "空の応答" として無意味 (":ircserv \r\n" になる) ので無視。
+  if (msg.empty())
+    return;
+  // 既に ":" prefix を持つメッセージ (稀な pre-formatted ケース) はそのまま。
+  // それ以外の numeric 応答 / PONG / ERROR 等は ":<serverName> " を先付け。
+  if (msg[0] == ':')
+    _appendLine(client, msg);
+  else
+    _appendLine(client, ":" + _serverName + " " + msg);
 }
 
 void ResponseSink::direct(Client &client, const std::string &msg) {

--- a/src/response/ResponseSink.cpp
+++ b/src/response/ResponseSink.cpp
@@ -16,11 +16,8 @@ void ResponseSink::_appendLine(Client &client, const std::string &msg) {
 }
 
 void ResponseSink::reply(Client &client, const std::string &msg) {
-  // 空文字列は "空の応答" として無意味 (":ircserv \r\n" になる) ので無視。
   if (msg.empty())
     return;
-  // 既に ":" prefix を持つメッセージ (稀な pre-formatted ケース) はそのまま。
-  // それ以外の numeric 応答 / PONG / ERROR 等は ":<serverName> " を先付け。
   if (msg[0] == ':')
     _appendLine(client, msg);
   else


### PR DESCRIPTION
Closes #56

## 概要
`001 alice :Welcome ...` のように server 発の応答に `:<servername>` prefix が欠落していた。RFC 2812 §2.3 は「server 発は必ず prefix を持つ」と規定。全 numeric と PONG/ERROR 等を対象に自動付与する。

## 変更内容

### `include/response/ResponseSink.hpp` / `src/response/ResponseSink.cpp`
- `_serverName` メンバを追加 (default `"ircserv"`)
- `explicit ResponseSink(const std::string& serverName)` ctor 追加
- `getServerName()` accessor 追加 (#49 welcome sequence 用の forward scaffolding)
- `reply()` に自動 prefix ロジック:
  - `msg` が空 → silent skip
  - `msg[0] == ':'` → そのまま (pre-formatted、直接使う稀ケース)
  - それ以外 → `":<serverName> " + msg` を先付け
- `direct()` / `broadcast()` / `broadcastExcept()` は元々 `":user!user@host ..."` prefix を持つ msg を受ける前提なので変更なし → double prefix 発生せず

## 挙動一覧

| 呼び出し元 | 送出前 msg | ResponseSink 経由後 |
|---|---|---|
| `rplWelcome` | `001 alice :Welcome ...` | `:ircserv 001 alice :Welcome ...` ✅ |
| `errNickNameInUse` | `433 * bob :Nickname is already in use` | `:ircserv 433 * bob :...` ✅ |
| `PingCommand PONG :12345` | `PONG :12345` | `:ircserv PONG :12345` ✅ |
| `QuitCommand ERROR ...` | `ERROR :Closing Link: ...` | `:ircserv ERROR :Closing Link: ...` (#63 merge 後) |
| `PrivMsgCommand direct` | `:bob!bob@host PRIVMSG alice :hi` | 変更なし (double prefix 発生せず) ✅ |
| `broadcast JOIN` | `:alice!... JOIN :#room` | 変更なし ✅ |

## テスト (4 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | JOIN → numeric 応答 | 001/331/353/366/324 に `:ircserv` prefix | ✅ |
| T2 | 2 client PRIVMSG/JOIN broadcast | user prefix のみ、double なし | ✅ |
| T3 | PING → PONG | `:ircserv PONG :<token>` | ✅ |
| T4 | 431 (未確定 nick 応答) | `:ircserv 431 * :No nickname given` | ✅ |

## サブエージェントレビュー結果
LGTM (NIT 3件のうち 1件反映):
- **反映** [NIT] 空 msg で `:ircserv \r\n` が出る問題 → `msg.empty() → return` guard 追加
- **defer** [NIT] `explicit` ctor / `getServerName()` は未使用 → #49 で使用予定の forward scaffolding、削除せず
- **defer** [NIT] `"ircserv"` hardcode → 将来の設定化は別 issue

## Refs
- RFC 2812 §2.3
- Related: #49 (welcome sequence)、#67 (`getServerName` 消費予定)