### PR TITLE
fix: 登録完了時に RPL_YOURHOST/CREATED/MYINFO (002-004) を送信

### DIFF
--- a/include/core/ServerContext.hpp
+++ b/include/core/ServerContext.hpp
@@ -19,6 +19,9 @@ class ServerContext {
   std::map<std::string, Channel*>& _channels;
   ResponseSink& _responseSink;
   const std::string& _password;
+  // 起動時刻を human-readable な文字列で保持し、
+  // 003 RPL_CREATED で client に返す。
+  std::string _createdAt;
 
  public:
   typedef std::pair<Channel*, bool> ChannelSlot;
@@ -48,6 +51,7 @@ class ServerContext {
   ResponseSink& responseSink();
   const ResponseSink& responseSink() const;
   const std::string& password() const;
+  const std::string& createdAt() const;
 };
 
 #endif

--- a/include/core/ServerContext.hpp
+++ b/include/core/ServerContext.hpp
@@ -19,8 +19,6 @@ class ServerContext {
   std::map<std::string, Channel*>& _channels;
   ResponseSink& _responseSink;
   const std::string& _password;
-  // 起動時刻を human-readable な文字列で保持し、
-  // 003 RPL_CREATED で client に返す。
   std::string _createdAt;
 
  public:

--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -14,6 +14,16 @@ class ReplyBuilder {
  public:
   static std::string rplWelcome(const std::string& clientName,
                                 const std::string& clientPrefix);
+  static std::string rplYourHost(const std::string& clientName,
+                                 const std::string& serverName,
+                                 const std::string& version);
+  static std::string rplCreated(const std::string& clientName,
+                                const std::string& createdAt);
+  static std::string rplMyInfo(const std::string& clientName,
+                               const std::string& serverName,
+                               const std::string& version,
+                               const std::string& userModes,
+                               const std::string& channelModes);
   static std::string rplChannelModeIs(const std::string& clientName,
                                       const std::string& channelName,
                                       const std::string& mode,

--- a/src/core/ServerContext.cpp
+++ b/src/core/ServerContext.cpp
@@ -9,8 +9,6 @@
 #include "ReplyBuilder.hpp"
 
 namespace {
-// 003 RPL_CREATED で使う human-readable な起動時刻 (localtime)。
-// C++98 に std::put_time が無いため strftime に固定 buffer を使う。
 std::string formatCreatedAt() {
   std::time_t now = std::time(NULL);
   std::tm* tm = std::localtime(&now);
@@ -21,7 +19,6 @@ std::string formatCreatedAt() {
   if (n == 0)
     return std::string("unknown");
   std::string result(buf, n);
-  // %Z が空展開する環境 (LC_ALL=C など) では末尾空白が残るので除去。
   while (!result.empty() && result[result.size() - 1] == ' ')
     result.erase(result.size() - 1);
   return result;
@@ -141,9 +138,6 @@ bool ServerContext::tryCompleteRegistration(Client& client) {
       !client.getUserName().empty()) {
     client.setRegistered(true);
 
-    // RFC 2812 §5.1: 登録完了時は 001-004 を順に送るのが標準。
-    // (MOTD 375/372/376 は本サーバは未実装 → 送信しない、多くの client は
-    //  MOTD 無くても問題なく登録完了と解釈する)
     const std::string& nick = client.getNickName();
     const std::string& serverName = _responseSink.getServerName();
     const std::string version = "0.1";

--- a/src/core/ServerContext.cpp
+++ b/src/core/ServerContext.cpp
@@ -1,11 +1,32 @@
 #include "ServerContext.hpp"
 #include <algorithm>
 #include <cctype>
+#include <ctime>
 #include <iostream>
 #include <vector>
 #include "HostCaseMapping.hpp"
 #include "IrcCaseMapping.hpp"
 #include "ReplyBuilder.hpp"
+
+namespace {
+// 003 RPL_CREATED で使う human-readable な起動時刻 (localtime)。
+// C++98 に std::put_time が無いため strftime に固定 buffer を使う。
+std::string formatCreatedAt() {
+  std::time_t now = std::time(NULL);
+  std::tm* tm = std::localtime(&now);
+  if (tm == NULL)
+    return std::string("unknown");
+  char buf[64];
+  std::size_t n = std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", tm);
+  if (n == 0)
+    return std::string("unknown");
+  std::string result(buf, n);
+  // %Z が空展開する環境 (LC_ALL=C など) では末尾空白が残るので除去。
+  while (!result.empty() && result[result.size() - 1] == ' ')
+    result.erase(result.size() - 1);
+  return result;
+}
+}  // namespace
 
 ServerContext::ServerContext(std::map<int, Client*>& clients,
                              std::map<std::string, Channel*>& channels,
@@ -14,7 +35,8 @@ ServerContext::ServerContext(std::map<int, Client*>& clients,
     : _clients(clients),
       _channels(channels),
       _responseSink(responseSink),
-      _password(password) {}
+      _password(password),
+      _createdAt(formatCreatedAt()) {}
 
 ServerContext::~ServerContext() {}
 
@@ -118,8 +140,24 @@ bool ServerContext::tryCompleteRegistration(Client& client) {
   if (client.isPassChecked() && !client.getNickName().empty() &&
       !client.getUserName().empty()) {
     client.setRegistered(true);
-    _responseSink.reply(client, ReplyBuilder::rplWelcome(client.getNickName(),
-                                                         client.getPrefix()));
+
+    // RFC 2812 §5.1: 登録完了時は 001-004 を順に送るのが標準。
+    // (MOTD 375/372/376 は本サーバは未実装 → 送信しない、多くの client は
+    //  MOTD 無くても問題なく登録完了と解釈する)
+    const std::string& nick = client.getNickName();
+    const std::string& serverName = _responseSink.getServerName();
+    const std::string version = "0.1";
+    const std::string umodes = "iwoOars";
+    const std::string cmodes = "itklo";
+
+    _responseSink.reply(client,
+                        ReplyBuilder::rplWelcome(nick, client.getPrefix()));
+    _responseSink.reply(client,
+                        ReplyBuilder::rplYourHost(nick, serverName, version));
+    _responseSink.reply(client, ReplyBuilder::rplCreated(nick, _createdAt));
+    _responseSink.reply(
+        client, ReplyBuilder::rplMyInfo(nick, serverName, version, umodes,
+                                        cmodes));
 
     std::cout << "[+] Client(FD: " << client.getFd()
               << ") has successfully logged in." << std::endl;
@@ -185,4 +223,8 @@ const ResponseSink& ServerContext::responseSink() const {
 
 const std::string& ServerContext::password() const {
   return _password;
+}
+
+const std::string& ServerContext::createdAt() const {
+  return _createdAt;
 }

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -6,6 +6,27 @@ std::string ReplyBuilder::rplWelcome(const std::string& clientName,
          clientPrefix;
 }
 
+std::string ReplyBuilder::rplYourHost(const std::string& clientName,
+                                      const std::string& serverName,
+                                      const std::string& version) {
+  return "002 " + clientName + " :Your host is " + serverName +
+         ", running version " + version;
+}
+
+std::string ReplyBuilder::rplCreated(const std::string& clientName,
+                                     const std::string& createdAt) {
+  return "003 " + clientName + " :This server was created " + createdAt;
+}
+
+std::string ReplyBuilder::rplMyInfo(const std::string& clientName,
+                                    const std::string& serverName,
+                                    const std::string& version,
+                                    const std::string& userModes,
+                                    const std::string& channelModes) {
+  return "004 " + clientName + " " + serverName + " " + version + " " +
+         userModes + " " + channelModes;
+}
+
 std::string ReplyBuilder::rplChannelModeIs(const std::string& clientName,
                                            const std::string& channelName,
                                            const std::string& mode,


### PR DESCRIPTION
Closes #49

> ⚠️ **stacked on #85** (base: `56-fix-server-prefix`)
> #85 が merge されると自動的に base が main に切り替わります。

## 概要
登録完了時に 001 RPL_WELCOME のみ送っていたのを RFC 2812 §5.1 に沿って 001-004 の 4 numeric を順次送信するよう修正。

## 変更内容

### `ReplyBuilder`
- `rplYourHost(nick, serverName, version)` → `002 ... :Your host is <s>, running version <v>`
- `rplCreated(nick, createdAt)` → `003 ... :This server was created <ts>`
- `rplMyInfo(nick, serverName, version, uModes, cModes)` → `004 ... <s> <v> <um> <cm>`

### `ServerContext`
- `_createdAt` (std::string) を追加、起動時に `formatCreatedAt()` で `"YYYY-MM-DD HH:MM:SS TZ"` 形式に整形して保持
  - `%Z` が空展開する環境向けの trailing space strip も込み
- `tryCompleteRegistration` で 001 → 002 → 003 → 004 の順に `_responseSink.reply()`
- version/umodes/cmodes は `"0.1"` / `"iwoOars"` / `"itklo"` を hardcoded

## 動作例
```
$ nc -C 127.0.0.1 6667
PASS testpass
NICK alice
USER alice 0 * :Alice
:ircserv 001 alice :Welcome to the Internet Relay Network alice!alice@127.0.0.1
:ircserv 002 alice :Your host is ircserv, running version 0.1
:ircserv 003 alice :This server was created 2026-08-07 19:41:54 JST
:ircserv 004 alice ircserv 0.1 iwoOars itklo
```

## サブエージェントレビュー結果
LGTM (NIT 1件反映 + フォローアップ提示):
- **反映** [NIT] `%Z` 空展開時の trailing space → strip 追加
- **defer** [NIT] `time()==-1` の防御 → 実質発生しない
- **defer** [NIT] hardcoded string を `static const` に → micro-opt
- **defer** [MINOR] MOTD (422 ERR_NOMOTD) 未送信 → 別 issue 化候補
- **defer** [MINOR] RPL_ISUPPORT (005) 未実装 → 別 issue 化候補

## Refs
- RFC 2812 §5.1
- Depends on: #85 (server prefix / getServerName 導入)