### PR TITLE
fix: make -j re が壊れる問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ clean:
 fclean: clean
 	rm -f $(NAME)
 
-re: fclean all
+re:
+	$(MAKE) fclean
+	$(MAKE) all
 
 fmt:
 	@echo "Formatting code..."


### PR DESCRIPTION
Closes #65

## 概要
`make -j re` を実行すると `fclean` と `all` が並列実行されてしまい、`fclean` が obj/*.o を削除している最中に `all` の link ステップが起動して `ld: cannot find obj/*.o` で失敗するケースを修正。

## 変更内容
```diff
-re: fclean all
+re:
+	$(MAKE) fclean
+	$(MAKE) all
```
`$(MAKE)` 経由でサブ make を呼ぶことで、recipe 内のコマンドが順次実行される特性を利用し fclean → all の順序を強制。GNU Make の jobserver は `$(MAKE)` に自動継承されるので `all` 内部の `-j` 並列は保たれる。

## テスト
```
$ make fclean && make -j re
c++ ... (parallel compile)
c++ -o ircserv ... obj/utils/IrcCaseMapping.o
$ ls ircserv
-rwxr-xr-x 1 koyon koyon 318952 ...
```
`ld: cannot find` エラーなく binary 生成成功。

## サブエージェントレビュー結果
LGTM 指摘なし。以下確認済:
- `.PHONY` に `re` 既登録
- TAB indent 維持 (`cat -A` で `^I` 確認)
- `$(MAKE)` で jobserver 継承
- `MAKEFLAGS` propagation 保持
- 他 target (`clean` / `fclean` / `%.o` pattern rule / `fmt`) 無影響

NIT: `make[1]: Entering/Leaving directory` 出力が出る (cosmetic のみ、機能上問題なし)