### PR TITLE
fix: ERR_UNKNOWNCOMMAND (421) と ERR_NORECIPIENT (411) に client nick を追加

### DIFF
--- a/include/response/ReplyBuilder.hpp
+++ b/include/response/ReplyBuilder.hpp
@@ -39,8 +39,10 @@ class ReplyBuilder {
                                        const std::string& target,
                                        const std::string& errCode,
                                        const std::string& abortMsg);
-  static std::string errUnknownCommand(const std::string& command);
-  static std::string errNoRecipient(const std::string& command);
+  static std::string errUnknownCommand(const std::string& clientName,
+                                       const std::string& command);
+  static std::string errNoRecipient(const std::string& clientName,
+                                    const std::string& command);
   static std::string errNoOrigin(const std::string& clientName);
   static std::string errNoTextToSend(const std::string& clientName);
   static std::string errNoNicknameGiven();

--- a/src/commands/PrivMsgCommand.cpp
+++ b/src/commands/PrivMsgCommand.cpp
@@ -8,7 +8,7 @@ PrivMsgCommand::~PrivMsgCommand() {}
 
 bool PrivMsgCommand::execute(CommandContext& ctx) {
   if (ctx.params().empty()) {
-    ctx.reply(ReplyBuilder::errNoRecipient("PRIVMSG"));
+    ctx.reply(ReplyBuilder::errNoRecipient(ctx.nick(), "PRIVMSG"));
     return true;
   }
   if (ctx.params().size() < 2 || ctx.params()[1].empty()) {

--- a/src/core/CommandDispatcher.cpp
+++ b/src/core/CommandDispatcher.cpp
@@ -53,7 +53,7 @@ bool CommandDispatcher::dispatch(CommandContext &ctx) {
       _commands.find(ctx.command());
   if (it == _commands.end()) {
     if (ctx.isRegistered()) {
-      ctx.reply(ReplyBuilder::errUnknownCommand(ctx.command()));
+      ctx.reply(ReplyBuilder::errUnknownCommand(ctx.nick(), ctx.command()));
       std::cout << "Unknown command from authenticated User: "
                 << ctx.command() << std::endl; // [TODO] この出力いらないなら消す
     }

--- a/src/response/ReplyBuilder.cpp
+++ b/src/response/ReplyBuilder.cpp
@@ -64,8 +64,9 @@ std::string ReplyBuilder::errTooManyTargets(const std::string& clientName,
     " recipients. " + abortMsg;
 }
 
-std::string ReplyBuilder::errUnknownCommand(const std::string& command) {
-  return "421 " + command + " :Unknown command";
+std::string ReplyBuilder::errUnknownCommand(const std::string& clientName,
+                                            const std::string& command) {
+  return "421 " + clientName + " " + command + " :Unknown command";
 }
 
 std::string ReplyBuilder::errCantSendToChannel(const std::string& clientName,
@@ -73,8 +74,9 @@ std::string ReplyBuilder::errCantSendToChannel(const std::string& clientName,
   return "404 " + clientName + " " + channelName + " :Cannot send to channel";
 }
 
-std::string ReplyBuilder::errNoRecipient(const std::string& command) {
-  return "411 :No recipient given (" + command + ")";
+std::string ReplyBuilder::errNoRecipient(const std::string& clientName,
+                                         const std::string& command) {
+  return "411 " + clientName + " :No recipient given (" + command + ")";
 }
 
 std::string ReplyBuilder::errNoOrigin(const std::string& clientName) {


### PR DESCRIPTION
Closes #70

## 概要
`421 ERR_UNKNOWNCOMMAND` と `411 ERR_NORECIPIENT` の応答フォーマットに client nick が抜けていた問題を修正 (PR #69 #58 と同種の defect)。RFC 2812 §2.4 では numeric reply の第 1 引数は常に対象 client の nick。

## 変更内容
- `ReplyBuilder::errUnknownCommand(clientName, command)` にシグネチャ変更
- `ReplyBuilder::errNoRecipient(clientName, command)` にシグネチャ変更
- `CommandDispatcher.cpp:56` を `ctx.nick()` 渡しに更新
- `PrivMsgCommand.cpp:11` を `ctx.nick()` 渡しに更新

## Before / After
| ケース | Before | After |
|---|---|---|
| `FOOBAR` (unknown cmd) | `421 FOOBAR :Unknown command` | `421 alice FOOBAR :Unknown command` ✅ |
| `PRIVMSG` (no target) | `411 :No recipient given (PRIVMSG)` | `411 alice :No recipient given (PRIVMSG)` ✅ |

## 安全性 (empty nick 発生しないか)
- **421**: dispatcher で `isRegistered()` guard 通過後にのみ発火 → nick 保証
- **411**: PRIVMSG は pre-registration list に無いため registered client からのみ → nick 保証

## サブエージェントレビュー結果
LGTM 指摘なし。全 caller (`grep -rn`) が更新済で compile 保証、sibling `err*` 全て `clientName` first の慣例に一致。

## Refs
- RFC 2812 §2.4 / §5.2
- PR #69 (#58) と同種の修正パターン