### PR TITLE
fix: MODE 他 return 路も partial success で broadcast する

### DIFF
--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -56,11 +56,6 @@ bool ModeCommand::execute(CommandContext &ctx) {
   size_t paramIndex = 2;
   std::string modeParams;
 
-  // 実際に適用できた flag のみを appliedMode として蓄積し、最後に一度だけ
-  // broadcast する。未知 flag に当たっても既知 flag は反映を続ける (#60)。
-  // 中断が必要な error (errKeySet / errNoSuchNick / errUserNotInChannel /
-  // errNeedMoreParams) は return true ではなく break でループを抜け、それまでに
-  // 適用済の flag を一度だけ broadcast してから return true する (#79)。
   std::string appliedMode;
   char lastAppliedSign = 0;
 
@@ -149,7 +144,6 @@ bool ModeCommand::execute(CommandContext &ctx) {
     }
   }
 
-  // 何一つ適用できなかった (全部 unknown flag) 場合は broadcast しない。
   if (!appliedMode.empty()) {
     ctx.broadcast(*channel,
                   ":" + ctx.prefix() + " MODE " + chName + " " + appliedMode +

--- a/src/commands/ModeCommand.cpp
+++ b/src/commands/ModeCommand.cpp
@@ -58,6 +58,9 @@ bool ModeCommand::execute(CommandContext &ctx) {
 
   // 実際に適用できた flag のみを appliedMode として蓄積し、最後に一度だけ
   // broadcast する。未知 flag に当たっても既知 flag は反映を続ける (#60)。
+  // 中断が必要な error (errKeySet / errNoSuchNick / errUserNotInChannel /
+  // errNeedMoreParams) は return true ではなく break でループを抜け、それまでに
+  // 適用済の flag を一度だけ broadcast してから return true する (#79)。
   std::string appliedMode;
   char lastAppliedSign = 0;
 
@@ -85,11 +88,11 @@ bool ModeCommand::execute(CommandContext &ctx) {
       if (adding) {
         if (ctx.params().size() <= paramIndex) {
           ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "MODE"));
-          return true;
+          break;
         }
         if (!channel->getPassword().empty()) {
           ctx.reply(ReplyBuilder::errKeySet(chName));
-          return true;
+          break;
         }
         channel->setPassword(ctx.params()[paramIndex]);
         modeParams += " " + ctx.params()[paramIndex++];
@@ -100,18 +103,18 @@ bool ModeCommand::execute(CommandContext &ctx) {
     } else if (flag == 'o') {
       if (ctx.params().size() <= paramIndex) {
         ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "MODE"));
-        return true;
+        break;
       }
       std::string targetNick = ctx.params()[paramIndex++];
       Client *targetClient = _serverCtx.findClientByNick(targetNick);
       if (targetClient == NULL) {
         ctx.reply(ReplyBuilder::errNoSuchNick(ctx.nick(), targetNick));
-        return true;
+        break;
       }
       if (!channel->hasMember(*targetClient)) {
         ctx.reply(
             ReplyBuilder::errUserNotInChannel(ctx.nick(), targetNick, chName));
-        return true;
+        break;
       }
       if (adding)
         channel->addOperator(*targetClient);
@@ -123,7 +126,7 @@ bool ModeCommand::execute(CommandContext &ctx) {
       if (adding) {
         if (ctx.params().size() <= paramIndex) {
           ctx.reply(ReplyBuilder::errNeedMoreParams(ctx.nick(), "MODE"));
-          return true;
+          break;
         }
         channel->setUserLimit(std::atoi(ctx.params()[paramIndex].c_str()));
         modeParams += " " + ctx.params()[paramIndex++];


### PR DESCRIPTION
Closes #79

> ⚠️ **stacked on #78** (base: `60-fix-mode-partial-success`)
> #78 が merge されると自動的に base が main に切り替わります。

## 概要
PR #78 (#60) では unknown flag のみ `continue` 化していたが、他 5 か所の error パス (errKeySet / errNoSuchNick / errUserNotInChannel / errNeedMoreParams×3) で `return true;` していたため、それまでに applied な flag が silent 反映のまま broadcast されない bug が残っていた。全 6 か所を `break;` に統一。

## 変更内容
`src/commands/ModeCommand.cpp` の中止系 return true × 6 → break:
- `+k` errNeedMoreParams (no password)
- `+k` errKeySet (already set)
- `+o` errNeedMoreParams (no target)
- `+o` errNoSuchNick (unknown target)
- `+o` errUserNotInChannel (target not member)
- `+l` errNeedMoreParams (no limit)

各 error 分岐は apply 前に break するので、失敗した flag は `appliedMode` に混じらない。break で for loop を抜けて既存の post-loop broadcast ロジックに合流。

## Before / After
| 入力 | Before | After |
|---|---|---|
| `+k first; +tk second` | 467 のみ、+t は silent 反映 | 467 + `MODE #x +t` broadcast ✅ |
| `+io ghost` | 401 のみ、+i は silent 反映 | 401 + `MODE #y +i` broadcast ✅ |
| `+tk` (no arg) | 461 のみ、+t は silent 反映 | 461 + `MODE #z +t` broadcast ✅ |
| `+to` (no arg) | 461 のみ、+t は silent 反映 | 461 + `MODE #new +t` broadcast ✅ |
| `+it` (all success) | 変わらず | 変わらず (backward compat) ✅ |

## サブエージェントレビュー結果
LGTM (BLOCKING 指摘 1件反映):
- 初回の Edit で `+o errNeedMoreParams` の 1 か所を見落としていた → reviewer 指摘後に修正
- 5 か所すべての sites でトレース済:
  - break は apply 前に発火するため `applied = true` に到達せず、appliedMode 純粋
  - paramIndex は break で loop 終了後は irrelevant
- backward compat 保持

## Refs
- Follows: PR #78 (#60 unknown flag partial success)
- RFC 2812 §3.2.3