### PR TITLE
fix: extractMessage を bool + out-param 返却に変更

### DIFF
--- a/include/domain/Client.hpp
+++ b/include/domain/Client.hpp
@@ -53,11 +53,6 @@ class Client {
 
   int getFd() const;
   void appendRecvBuffer(const std::string& data);
-  // buffer から 1 メッセージ分 (次の "\n" まで) を取り出して outMsg に代入し
-  // true を返す。まだ完全な行が無ければ false を返し outMsg は触らない。
-  // 空行 (LF 単独 / CRLF 単独) の場合も true を返して空文字を代入するため、
-  // 呼び出し側は "buffer 消費完了 (false)" と "空行を消費 (true, empty)" を
-  // 区別できる (#67)。
   bool extractMessage(std::string& outMsg);
 
   // sendBuffer

--- a/include/domain/Client.hpp
+++ b/include/domain/Client.hpp
@@ -53,7 +53,12 @@ class Client {
 
   int getFd() const;
   void appendRecvBuffer(const std::string& data);
-  std::string extractMessage();
+  // buffer から 1 メッセージ分 (次の "\n" まで) を取り出して outMsg に代入し
+  // true を返す。まだ完全な行が無ければ false を返し outMsg は触らない。
+  // 空行 (LF 単独 / CRLF 単独) の場合も true を返して空文字を代入するため、
+  // 呼び出し側は "buffer 消費完了 (false)" と "空行を消費 (true, empty)" を
+  // 区別できる (#67)。
+  bool extractMessage(std::string& outMsg);
 
   // sendBuffer
   void appendSendBuffer(const std::string& msg);

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -265,7 +265,12 @@ Server::_handleClientMessage(struct pollfd &clientPollFd) {
 
     std::string rawMsg;
 
-    while ((rawMsg = _clients[clientPollFd.fd]->extractMessage()) != "") {
+    while (_clients[clientPollFd.fd]->extractMessage(rawMsg)) {
+      // 空行 ("\r\n" 単独) は無視する。IRC プロトコル上意味を持たない上、
+      // Message parser が空 command として扱うと 421 UNKNOWN が返る等の
+      // 副作用が出るため、caller 側で silent drop する。
+      if (rawMsg.empty())
+        continue;
       Message msg(rawMsg);
       if (!_executeCommand(_clients[clientPollFd.fd], msg)) {
         return DISCONNECT;

--- a/src/core/Server.cpp
+++ b/src/core/Server.cpp
@@ -266,9 +266,6 @@ Server::_handleClientMessage(struct pollfd &clientPollFd) {
     std::string rawMsg;
 
     while (_clients[clientPollFd.fd]->extractMessage(rawMsg)) {
-      // 空行 ("\r\n" 単独) は無視する。IRC プロトコル上意味を持たない上、
-      // Message parser が空 command として扱うと 421 UNKNOWN が返る等の
-      // 副作用が出るため、caller 側で silent drop する。
       if (rawMsg.empty())
         continue;
       Message msg(rawMsg);

--- a/src/domain/Client.cpp
+++ b/src/domain/Client.cpp
@@ -110,13 +110,13 @@ void Client::appendRecvBuffer(const std::string& data) {
   _recvBuffer += data;
 }
 
-std::string Client::extractMessage() {
+bool Client::extractMessage(std::string& outMsg) {
   // RFC 2812: メッセージ境界は CR-LF。ただし nc など LF のみで送るクライアントも
   // 実運用では珍しくないため、LF を境界として検出しつつ、直前の CR を除去して
   // 両方の終端表現を受け付ける。
   std::string::size_type pos = _recvBuffer.find('\n');
   if (pos == std::string::npos)
-    return "";
+    return false;
 
   std::string::size_type msgEnd = pos;
   if (msgEnd > 0 && _recvBuffer[msgEnd - 1] == '\r')
@@ -128,9 +128,9 @@ std::string Client::extractMessage() {
   if (msgEnd > IrcLimits::MAX_MSG_LEN)
     msgEnd = IrcLimits::MAX_MSG_LEN;
 
-  std::string msg = _recvBuffer.substr(0, msgEnd);
+  outMsg = _recvBuffer.substr(0, msgEnd);
   _recvBuffer.erase(0, pos + 1);
-  return msg;
+  return true;
 }
 
 // sendBuffer


### PR DESCRIPTION
Closes #67

> ⚠️ **stacked on #83** (base: `64-fix-message-length-limit` → `54-fix-parser-crlf` → main)
> upstream PR が merge されるにつれて自動的に base が繰り上がります。

## 概要
PR #66 (#54) で空行 (`\r\n` 単独) が正しく `""` を返すようになった副作用で、Server 側の
```cpp
while ((rawMsg = extractMessage()) != "") { ... }
```
が空行で早期 break する問題を修正 (#67)。

`extractMessage` のシグネチャを **bool + out-param** に変更し「buffer 消費完了」と「空行を消費」を区別可能に。空行は caller で silent drop。

## 変更内容

### `include/domain/Client.hpp` / `src/domain/Client.cpp`
```diff
-std::string extractMessage();
+bool extractMessage(std::string& outMsg);
```
- false: buffer に完全な行が無い (outMsg 未変更)
- true: 1 行取り出し完了 (outMsg 代入、空行なら空文字)

### `src/core/Server.cpp::_handleClientMessage`
```diff
-while ((rawMsg = extractMessage()) != "") {
+while (extractMessage(rawMsg)) {
+  if (rawMsg.empty()) continue;  // 空行 silent drop
```

## Before / After
```
send: "\r\n\r\nJOIN #x\r\n"  (1 packet)
```
| | Before | After |
|---|---|---|
| 最初の \r\n | extractMessage → "" → while break | true+empty → continue |
| 2 番目の \r\n | (未処理、buffer に残る) | true+empty → continue |
| JOIN #x | 次の recv() が来るまで永遠に stuck | 同 iteration で処理 → 応答返却 |

## テスト (4 パターン)
| # | シナリオ | 期待 | 結果 |
|---|---|---|---|
| T1 | 空行を挟んだ PASS/NICK/USER/JOIN | JOIN 応答返却 | ✅ |
| T2 | 1 packet に \r\n\r\nJOIN | JOIN 応答返却 | ✅ |
| T3 | 通常フロー (backward compat) | 変わらず | ✅ |
| T4 | LF-only 空行 | JOIN 応答返却 | ✅ |

## サブエージェントレビュー結果
LGTM (NIT 1件反映):
- **反映** doc comment の空行例 (`:" 単独` は誤り) → 「LF 単独 / CRLF 単独」に訂正
- `outMsg` は false 時に触られない contract 遵守 (defense-in-depth も caller 側 `std::string rawMsg;` が empty init で安全)
- MAX_MSG_LEN truncation (PR #83) の挙動保持
- 512-byte overflow / partial line / 空行連続の全ケース trace 済

## Refs
- Depends on: #66 (#54) と #83 (#64)
- RFC 2812 §2.3