### PR TITLE
fix: RPL_NAMREPLY (353) を chunk に分割して silent truncation を回避

### DIFF
--- a/include/commands/JoinCommand.hpp
+++ b/include/commands/JoinCommand.hpp
@@ -13,10 +13,6 @@ private:
 	JoinCommand(const JoinCommand &other);
 	JoinCommand &operator=(const JoinCommand &other);
 
-	// member 一覧を "@op user1 user2 …" 形式で並べた文字列を
-	// maxChunkLen byte 以内の chunk に分割して返す。
-	// 各 chunk は space 区切り。大規模 channel の RPL_NAMREPLY (353) が
-	// 512 byte overflow して truncate されないよう複数 line 分割 (#84)。
 	static std::vector<std::string> _generateChannelMemberChunks(
 	    const Channel &channel, std::size_t maxChunkLen);
 

--- a/include/commands/JoinCommand.hpp
+++ b/include/commands/JoinCommand.hpp
@@ -4,6 +4,7 @@
 #include "ACommand.hpp"
 #include "ServerContext.hpp"
 #include <string>
+#include <vector>
 
 class JoinCommand : public ACommand {
 private:
@@ -12,7 +13,12 @@ private:
 	JoinCommand(const JoinCommand &other);
 	JoinCommand &operator=(const JoinCommand &other);
 
-	static std::string _generateChannelMemberStr(const Channel &channel);
+	// member 一覧を "@op user1 user2 …" 形式で並べた文字列を
+	// maxChunkLen byte 以内の chunk に分割して返す。
+	// 各 chunk は space 区切り。大規模 channel の RPL_NAMREPLY (353) が
+	// 512 byte overflow して truncate されないよう複数 line 分割 (#84)。
+	static std::vector<std::string> _generateChannelMemberChunks(
+	    const Channel &channel, std::size_t maxChunkLen);
 
 public:
 	JoinCommand(ServerContext &serverCtx);

--- a/src/commands/JoinCommand.cpp
+++ b/src/commands/JoinCommand.cpp
@@ -9,19 +9,34 @@
 JoinCommand::JoinCommand(ServerContext& serverCtx) : _serverCtx(serverCtx) {}
 JoinCommand::~JoinCommand() {}
 
-std::string JoinCommand::_generateChannelMemberStr(const Channel& channel) {
-  std::string namesList;
+std::vector<std::string> JoinCommand::_generateChannelMemberChunks(
+    const Channel& channel, std::size_t maxChunkLen) {
+  std::vector<std::string> chunks;
+  std::string current;
   const std::map<int, Client*>& members = channel.getMembers();
 
   for (std::map<int, Client*>::const_iterator it = members.begin();
        it != members.end(); ++it) {
-    if (!namesList.empty())
-      namesList += " ";
+    // "@nick" もしくは "nick"
+    std::string name;
     if (channel.isOperator(*(it->second)))
-      namesList += "@";
-    namesList += it->second->getNickName();
+      name += "@";
+    name += it->second->getNickName();
+
+    // 追加すると maxChunkLen を超える場合は現行 chunk を確定して new chunk へ
+    std::size_t added = (current.empty() ? 0u : 1u) + name.length();
+    if (!current.empty() && current.length() + added > maxChunkLen) {
+      chunks.push_back(current);
+      current = name;
+    } else {
+      if (!current.empty())
+        current += " ";
+      current += name;
+    }
   }
-  return namesList;
+  if (!current.empty())
+    chunks.push_back(current);
+  return chunks;
 }
 
 bool JoinCommand::execute(CommandContext& ctx) {
@@ -89,8 +104,16 @@ bool JoinCommand::execute(CommandContext& ctx) {
         ctx.reply(
             ReplyBuilder::rplTopic(ctx.nick(), chName, channel->getTopic()));
 
-      ctx.reply(ReplyBuilder::rplNamReply(ctx.nick(), chName,
-                                          _generateChannelMemberStr(*channel)));
+      // 353 の trailing (":<content>") に入る安全な最大長を控えめに 400 byte
+      // とする。ResponseSink 側の 510 byte truncate に確実に収まる予算。
+      // (":ircserv " ~9 + "353 " ~4 + nick ~9 + " = " + chan ~50 + " :" = 高々
+      //  80 byte 弱 → 400 byte content で total 500 byte 未満)
+      const std::size_t MAX_NAMES_CHUNK_LEN = 400;
+      std::vector<std::string> chunks =
+          _generateChannelMemberChunks(*channel, MAX_NAMES_CHUNK_LEN);
+      for (std::size_t i = 0; i < chunks.size(); ++i) {
+        ctx.reply(ReplyBuilder::rplNamReply(ctx.nick(), chName, chunks[i]));
+      }
       ctx.reply(ReplyBuilder::rplEndOfNames(ctx.nick(), chName));
     }
   }

--- a/src/commands/JoinCommand.cpp
+++ b/src/commands/JoinCommand.cpp
@@ -17,13 +17,11 @@ std::vector<std::string> JoinCommand::_generateChannelMemberChunks(
 
   for (std::map<int, Client*>::const_iterator it = members.begin();
        it != members.end(); ++it) {
-    // "@nick" もしくは "nick"
     std::string name;
     if (channel.isOperator(*(it->second)))
       name += "@";
     name += it->second->getNickName();
 
-    // 追加すると maxChunkLen を超える場合は現行 chunk を確定して new chunk へ
     std::size_t added = (current.empty() ? 0u : 1u) + name.length();
     if (!current.empty() && current.length() + added > maxChunkLen) {
       chunks.push_back(current);
@@ -104,10 +102,6 @@ bool JoinCommand::execute(CommandContext& ctx) {
         ctx.reply(
             ReplyBuilder::rplTopic(ctx.nick(), chName, channel->getTopic()));
 
-      // 353 の trailing (":<content>") に入る安全な最大長を控えめに 400 byte
-      // とする。ResponseSink 側の 510 byte truncate に確実に収まる予算。
-      // (":ircserv " ~9 + "353 " ~4 + nick ~9 + " = " + chan ~50 + " :" = 高々
-      //  80 byte 弱 → 400 byte content で total 500 byte 未満)
       const std::size_t MAX_NAMES_CHUNK_LEN = 400;
       std::vector<std::string> chunks =
           _generateChannelMemberChunks(*channel, MAX_NAMES_CHUNK_LEN);


### PR DESCRIPTION
Closes #84

> ⚠️ **stacked on #74** (base: `52-fix-kick-multi-target`)
> #74 が merge されると自動的に base が main に切り替わります。

## 概要
PR #83 (#64) で `ResponseSink::_appendLine` が 510 byte で送信 truncate するようになった副作用で、`RPL_NAMREPLY` (353) が大規模 channel で silent 切断される問題を修正。RFC 2812 §3.2.5 に従い複数 353 line に分割。

## 変更内容

### `include/commands/JoinCommand.hpp`
- helper signature を変更:
  - 旧: `static std::string _generateChannelMemberStr(const Channel&)`
  - 新: `static std::vector<std::string> _generateChannelMemberChunks(const Channel&, std::size_t maxChunkLen)`

### `src/commands/JoinCommand.cpp`
- chunk 生成ロジック: `current` を蓄積 → 追加すると `maxChunkLen` 超過なら flush して new chunk
- `execute` で `MAX_NAMES_CHUNK_LEN = 400` にし、各 chunk を個別 353 line で送信、最後に 1 回 366 END OF NAMES

## MAX_NAMES_CHUNK_LEN=400 の根拠
- Wire: `:ircserv 353 <nick> = <chan> :<content>\r\n`
- 固定 overhead ≤ 20 byte, 可変 (nick ≤9 + chan ≤50) ≤ 59 byte → non-content ≤ 79 byte
- 512 - 79 = 433 byte が理論最大 → 400 に控えめに設定してマージン確保

## テスト
実際に chunking を発火させるため MAX を 15 に一時的に下げて 5 client + observer で検証:
```
observer が見る内容:
353 observer = #big :@usr0 usr1 usr2
353 observer = #big :usr3 usr4
353 observer = #big :observer
366 observer #big :End of /NAMES list
```
3 chunk 分割 + 1 END OF NAMES ✅

MAX を 400 に戻して backward compat 確認済 (少人数 channel は 1 chunk)。

## サブエージェントレビュー結果
LGTM。NIT のみ (すべて defer):
- `:ircserv` prefix (PR #85 #56) を前提としたコメント文言 → rebase 後に自然に整合
- `added` 計算が first iter で dead work → micro-opt
- 空 channel での空 vector 返却 → JOIN codepath では unreachable
- `+` voice prefix 未対応 → subject スコープ外

## Refs
- Related: PR #83 (#64) が truncate 挙動を露呈
- RFC 2812 §3.2.5